### PR TITLE
Fix for case sensitive filesystems

### DIFF
--- a/lib/Model/CreateChargeRequest.php
+++ b/lib/Model/CreateChargeRequest.php
@@ -141,7 +141,7 @@ class CreateChargeRequest implements ArrayAccess
         if ($this->container['currency'] === null) {
             $invalid_properties[] = "'currency' can't be null";
         }
-        $allowed_values = currencyUtil::isValidCurrency($this->container['currency']);
+        $allowed_values = CurrencyUtil::isValidCurrency($this->container['currency']);
         if (!$allowed_values['valid']) {
             $invalid_properties[] = $allowed_values['message'];
         }
@@ -167,7 +167,7 @@ class CreateChargeRequest implements ArrayAccess
         if ($this->container['currency'] === null) {
             return false;
         }
-        $allowed_values = currencyUtil::isValidCurrency($this->container['currency']);
+        $allowed_values = CurrencyUtil::isValidCurrency($this->container['currency']);
         if (!$allowed_values['valid']) {
             return false;
         }
@@ -254,7 +254,7 @@ class CreateChargeRequest implements ArrayAccess
      */
     public function setCurrency($currency)
     {
-        $allowed_values = currencyUtil::isValidCurrency($currency);
+        $allowed_values = CurrencyUtil::isValidCurrency($currency);
         if (!$allowed_values['valid']) {
             throw new \InvalidArgumentException($allowed_values['message']);
         }

--- a/lib/Model/ShopperStatistics.php
+++ b/lib/Model/ShopperStatistics.php
@@ -170,7 +170,7 @@ class ShopperStatistics implements ArrayAccess
     {
         $invalid_properties = array();
 
-        $allowed_values = currencyUtil::isValidCurrency($this->container['currency']);
+        $allowed_values = CurrencyUtil::isValidCurrency($this->container['currency']);
         if (!$allowed_values['valid']) {
             $invalid_properties[] = $allowed_values['message'];
         }
@@ -192,7 +192,7 @@ class ShopperStatistics implements ArrayAccess
     public function valid()
     {
 
-        $allowed_values = currencyUtil::isValidCurrency($this->container['currency']);
+        $allowed_values = CurrencyUtil::isValidCurrency($this->container['currency']);
         if (!$allowed_values['valid']) {
             return false;
         }
@@ -367,7 +367,7 @@ class ShopperStatistics implements ArrayAccess
      */
     public function setCurrency($currency)
     {
-        $allowed_values = currencyUtil::isValidCurrency($currency);
+        $allowed_values = CurrencyUtil::isValidCurrency($currency);
         if (!is_null($currency) && (!$allowed_values['valid'])) {
             throw new \InvalidArgumentException($allowed_values['message']);
         }


### PR DESCRIPTION
This fixes an error that currencyUtil class is not found, causing payments to fail when setting the currency.