### PR TITLE
ZES-82: refactor SDK, add Rector/PHP-CS-Fixer tooling, fix PHP 8 warning

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+# Normalize line endings to LF on checkout and in the repo, on every platform.
+# Overrides a global core.autocrlf=true so the tree stays consistent with .editorconfig.
+* text=auto eol=lf
+*.zip binary

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,14 @@
 .DS_Store
 .php_cs
+.php-cs-fixer.php
 git_push.sh
 /vendor
 *.lock
 *.ini
 /.idea
+
+# Tooling caches
+/build/.php-cs-fixer.cache
+/build/.phpunit.cache
+.phpunit.result.cache
+.rector-cache

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+$finder = PhpCsFixer\Finder::create()
+    ->in([
+        __DIR__ . '/lib',
+        __DIR__ . '/test',
+    ])
+    ->name('*.php');
+
+return (new PhpCsFixer\Config())
+    ->setRiskyAllowed(true)
+    ->setRules([
+        '@PSR12' => true,
+        'array_syntax' => ['syntax' => 'short'],
+        'no_unused_imports' => true,
+        'ordered_imports' => ['sort_algorithm' => 'alpha'],
+        'single_quote' => true,
+        'trailing_comma_in_multiline' => true,
+        'no_trailing_whitespace' => true,
+        'no_whitespace_in_blank_line' => true,
+        'blank_line_after_namespace' => true,
+        'single_blank_line_at_eof' => true,
+    ])
+    ->setFinder($finder)
+    ->setCacheFile(__DIR__ . '/build/.php-cs-fixer.cache');

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,39 @@
+# Local tooling — ephemeral standard images only, no build, no custom Dockerfile.
+# PHP tooling/tests run on a PINNED php:8.1-cli (NOT the latest the composer image ships).
+# composer install runs in the official composer image; dependency resolution is
+# governed by config.platform.php (8.1.0) in composer.json, so it stays consistent.
+PHP_IMAGE      ?= php:8.1-cli
+COMPOSER_IMAGE ?= composer:2
+
+RUN_OPTS := --rm -v "$(CURDIR)":/app -w /app -u $$(id -u):$$(id -g)
+PHP      := docker run $(RUN_OPTS) $(PHP_IMAGE)
+COMPOSER := docker run $(RUN_OPTS) -e COMPOSER_HOME=/tmp/composer $(COMPOSER_IMAGE)
+
+.PHONY: help install rector rector-fix cs cs-fix lint test shell
+
+help: ## Show this help
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | \
+		awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-12s\033[0m %s\n", $$1, $$2}'
+
+install: ## composer install (ephemeral composer image)
+	$(COMPOSER) composer install
+
+rector: ## Rector dry-run (report only, changes nothing)
+	$(PHP) vendor/bin/rector process --dry-run
+
+rector-fix: ## Apply Rector changes
+	$(PHP) vendor/bin/rector process
+
+cs: ## PHP-CS-Fixer dry-run with diff (changes nothing)
+	$(PHP) vendor/bin/php-cs-fixer fix --dry-run --diff
+
+cs-fix: ## Apply PHP-CS-Fixer changes
+	$(PHP) vendor/bin/php-cs-fixer fix
+
+lint: cs rector ## Run both checks in dry-run mode
+
+test: ## Run PHPUnit
+	$(PHP) vendor/bin/phpunit
+
+shell: ## Open a shell in the PHP container
+	$(PHP) bash

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "zipmoney/merchantapi-php",
-    "version": "1.0.18",
+    "version": "1.0.19",
     "description": "",
     "keywords": [
         "zipmoney",
@@ -18,7 +18,15 @@
         "homepage": "https://github.com/zipMoney/merchantapi-php"
     }],
     "scripts": {
-        "publish": "sh ./build/shell/publish.sh"
+        "publish": "sh ./build/shell/publish.sh",
+        "rector": "rector process --dry-run",
+        "rector:fix": "rector process",
+        "cs": "php-cs-fixer fix --dry-run --diff",
+        "cs:fix": "php-cs-fixer fix",
+        "lint": [
+            "@cs",
+            "@rector"
+        ]
     },
     "require": {
         "php": ">=8.0",
@@ -28,7 +36,17 @@
     },
     "require-dev": {
         "squizlabs/php_codesniffer": "~2.6",
-        "phpunit/phpunit": "^10"
+        "phpunit/phpunit": "^10",
+        "rector/rector": "^1.2",
+        "friendsofphp/php-cs-fixer": "^3.64"
+    },
+    "config": {
+        "platform": {
+            "php": "8.1.0"
+        },
+        "allow-plugins": {
+            "rector/extension-installer": true
+        }
     },
     "autoload": {
         "psr-4": {

--- a/lib/Api/ChargesApi.php
+++ b/lib/Api/ChargesApi.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 /**
@@ -14,24 +15,28 @@ namespace zipMoney\Api;
 
 use zipMoney\ApiClient;
 use zipMoney\ApiException;
+use zipMoney\Model\CaptureChargeRequest;
+use zipMoney\Model\Charge;
+use zipMoney\Model\ChargeCollection;
+use zipMoney\Model\CreateChargeRequest;
 
 class ChargesApi
 {
     /**
      * API Client.
      *
-     * @var \zipMoney\ApiClient instance of the ApiClient
+     * @var ApiClient instance of the ApiClient
      */
-    protected $apiClient;
+    protected ?ApiClient $apiClient;
 
     /**
      * Constructor.
      *
-     * @param null|\zipMoney\ApiClient $apiClient The api client to use
+     * @param null|ApiClient $apiClient The api client to use
      */
-    public function __construct(?\zipMoney\ApiClient $apiClient = null)
+    public function __construct(?ApiClient $apiClient = null)
     {
-        if ($apiClient === null) {
+        if (!$apiClient instanceof ApiClient) {
             $apiClient = new ApiClient();
         }
         $this->apiClient = $apiClient;
@@ -40,9 +45,9 @@ class ChargesApi
     /**
      * Get API client.
      *
-     * @return \zipMoney\ApiClient get the API client
+     * @return ApiClient get the API client
      */
-    public function getApiClient()
+    public function getApiClient(): ?ApiClient
     {
         return $this->apiClient;
     }
@@ -50,11 +55,9 @@ class ChargesApi
     /**
      * Set the API client.
      *
-     * @param \zipMoney\ApiClient $apiClient set the API client
-     *
-     * @return ChargesApi
+     * @param ApiClient $apiClient set the API client
      */
-    public function setApiClient(\zipMoney\ApiClient $apiClient)
+    public function setApiClient(ApiClient $apiClient): static
     {
         $this->apiClient = $apiClient;
 
@@ -69,9 +72,9 @@ class ChargesApi
      * @param string $id              The id of the authorised charge (required)
      * @param string $idempotency_key The unique idempotency key. (optional)
      *
-     * @throws \zipMoney\ApiException on non-2xx response
+     * @throws ApiException on non-2xx response
      *
-     * @return \zipMoney\Model\Charge
+     * @return Charge
      */
     public function chargesCancel($id, $idempotency_key = null)
     {
@@ -88,7 +91,7 @@ class ChargesApi
      * @param string $id              The id of the authorised charge (required)
      * @param string $idempotency_key The unique idempotency key. (optional)
      *
-     * @throws \zipMoney\ApiException on non-2xx response
+     * @throws ApiException on non-2xx response
      *
      * @return array of \zipMoney\Model\Charge, HTTP status code, HTTP response headers (array of strings)
      */
@@ -117,7 +120,7 @@ class ChargesApi
         // path params
         if ($id !== null) {
             $resourcePath = str_replace(
-                '{' . 'id' . '}',
+                '{id}',
                 $this->apiClient->getSerializer()->toPathValue($id),
                 $resourcePath
             );
@@ -128,7 +131,7 @@ class ChargesApi
         // for model (json/xml)
         if (isset($_tempBody)) {
             $httpBody = $_tempBody; // $_tempBody is the method argument, if present
-        } elseif (count($formParams) > 0) {
+        } elseif ($formParams !== []) {
             $httpBody = $formParams; // for HTTP post (form)
         }
         // this endpoint requires API key authentication
@@ -157,17 +160,8 @@ class ChargesApi
                     $e->setResponseObject($data);
                     break;
                 case 400:
-                    $data = $this->apiClient->getSerializer()->deserialize($e->getResponseBody(), '\zipMoney\Model\ErrorResponse', $e->getResponseHeaders());
-                    $e->setResponseObject($data);
-                    break;
                 case 401:
-                    $data = $this->apiClient->getSerializer()->deserialize($e->getResponseBody(), '\zipMoney\Model\ErrorResponse', $e->getResponseHeaders());
-                    $e->setResponseObject($data);
-                    break;
                 case 402:
-                    $data = $this->apiClient->getSerializer()->deserialize($e->getResponseBody(), '\zipMoney\Model\ErrorResponse', $e->getResponseHeaders());
-                    $e->setResponseObject($data);
-                    break;
                 case 409:
                     $data = $this->apiClient->getSerializer()->deserialize($e->getResponseBody(), '\zipMoney\Model\ErrorResponse', $e->getResponseHeaders());
                     $e->setResponseObject($data);
@@ -184,12 +178,12 @@ class ChargesApi
      * Capture a charge
      *
      * @param string                               $id              The id of the authorised charge (required)
-     * @param \zipMoney\Model\CaptureChargeRequest $body            (optional)
+     * @param CaptureChargeRequest $body (optional)
      * @param string                               $idempotency_key The unique idempotency key. (optional)
      *
-     * @throws \zipMoney\ApiException on non-2xx response
+     * @throws ApiException on non-2xx response
      *
-     * @return \zipMoney\Model\Charge
+     * @return Charge
      */
     public function chargesCapture($id, $body = null, $idempotency_key = null)
     {
@@ -204,10 +198,10 @@ class ChargesApi
      * Capture a charge
      *
      * @param string                               $id              The id of the authorised charge (required)
-     * @param \zipMoney\Model\CaptureChargeRequest $body            (optional)
+     * @param CaptureChargeRequest $body (optional)
      * @param string                               $idempotency_key The unique idempotency key. (optional)
      *
-     * @throws \zipMoney\ApiException on non-2xx response
+     * @throws ApiException on non-2xx response
      *
      * @return array of \zipMoney\Model\Charge, HTTP status code, HTTP response headers (array of strings)
      */
@@ -236,7 +230,7 @@ class ChargesApi
         // path params
         if ($id !== null) {
             $resourcePath = str_replace(
-                '{' . 'id' . '}',
+                '{id}',
                 $this->apiClient->getSerializer()->toPathValue($id),
                 $resourcePath
             );
@@ -253,7 +247,7 @@ class ChargesApi
         // for model (json/xml)
         if (isset($_tempBody)) {
             $httpBody = $_tempBody; // $_tempBody is the method argument, if present
-        } elseif (count($formParams) > 0) {
+        } elseif ($formParams !== []) {
             $httpBody = $formParams; // for HTTP post (form)
         }
         // this endpoint requires API key authentication
@@ -282,17 +276,8 @@ class ChargesApi
                     $e->setResponseObject($data);
                     break;
                 case 400:
-                    $data = $this->apiClient->getSerializer()->deserialize($e->getResponseBody(), '\zipMoney\Model\ErrorResponse', $e->getResponseHeaders());
-                    $e->setResponseObject($data);
-                    break;
                 case 401:
-                    $data = $this->apiClient->getSerializer()->deserialize($e->getResponseBody(), '\zipMoney\Model\ErrorResponse', $e->getResponseHeaders());
-                    $e->setResponseObject($data);
-                    break;
                 case 402:
-                    $data = $this->apiClient->getSerializer()->deserialize($e->getResponseBody(), '\zipMoney\Model\ErrorResponse', $e->getResponseHeaders());
-                    $e->setResponseObject($data);
-                    break;
                 case 409:
                     $data = $this->apiClient->getSerializer()->deserialize($e->getResponseBody(), '\zipMoney\Model\ErrorResponse', $e->getResponseHeaders());
                     $e->setResponseObject($data);
@@ -308,12 +293,12 @@ class ChargesApi
      *
      * Create a charge
      *
-     * @param \zipMoney\Model\CreateChargeRequest $body            (optional)
+     * @param CreateChargeRequest $body (optional)
      * @param string                              $idempotency_key The unique idempotency key. (optional)
      *
-     * @throws \zipMoney\ApiException on non-2xx response
+     * @throws ApiException on non-2xx response
      *
-     * @return \zipMoney\Model\Charge
+     * @return Charge
      */
     public function chargesCreate($body = null, $idempotency_key = null)
     {
@@ -327,10 +312,10 @@ class ChargesApi
      *
      * Create a charge
      *
-     * @param \zipMoney\Model\CreateChargeRequest $body            (optional)
+     * @param CreateChargeRequest $body (optional)
      * @param string                              $idempotency_key The unique idempotency key. (optional)
      *
-     * @throws \zipMoney\ApiException on non-2xx response
+     * @throws ApiException on non-2xx response
      *
      * @return array of \zipMoney\Model\Charge, HTTP status code, HTTP response headers (array of strings)
      */
@@ -364,7 +349,7 @@ class ChargesApi
         // for model (json/xml)
         if (isset($_tempBody)) {
             $httpBody = $_tempBody; // $_tempBody is the method argument, if present
-        } elseif (count($formParams) > 0) {
+        } elseif ($formParams !== []) {
             $httpBody = $formParams; // for HTTP post (form)
         }
         // this endpoint requires API key authentication
@@ -393,21 +378,9 @@ class ChargesApi
                     $e->setResponseObject($data);
                     break;
                 case 400:
-                    $data = $this->apiClient->getSerializer()->deserialize($e->getResponseBody(), '\zipMoney\Model\ErrorResponse', $e->getResponseHeaders());
-                    $e->setResponseObject($data);
-                    break;
                 case 401:
-                    $data = $this->apiClient->getSerializer()->deserialize($e->getResponseBody(), '\zipMoney\Model\ErrorResponse', $e->getResponseHeaders());
-                    $e->setResponseObject($data);
-                    break;
                 case 402:
-                    $data = $this->apiClient->getSerializer()->deserialize($e->getResponseBody(), '\zipMoney\Model\ErrorResponse', $e->getResponseHeaders());
-                    $e->setResponseObject($data);
-                    break;
                 case 403:
-                    $data = $this->apiClient->getSerializer()->deserialize($e->getResponseBody(), '\zipMoney\Model\ErrorResponse', $e->getResponseHeaders());
-                    $e->setResponseObject($data);
-                    break;
                 case 409:
                     $data = $this->apiClient->getSerializer()->deserialize($e->getResponseBody(), '\zipMoney\Model\ErrorResponse', $e->getResponseHeaders());
                     $e->setResponseObject($data);
@@ -428,9 +401,9 @@ class ChargesApi
      * @param int    $limit  Number of items to retrieve when paging (optional, default to 100)
      * @param string $expand Allows expanding related entities in the response. Only valid entry is &#39;customer&#39; (optional)
      *
-     * @throws \zipMoney\ApiException on non-2xx response
+     * @throws ApiException on non-2xx response
      *
-     * @return \zipMoney\Model\ChargeCollection
+     * @return ChargeCollection
      */
     public function chargesList($state = null, $skip = null, $limit = null, $expand = null)
     {
@@ -449,7 +422,7 @@ class ChargesApi
      * @param int    $limit  Number of items to retrieve when paging (optional, default to 100)
      * @param string $expand Allows expanding related entities in the response. Only valid entry is &#39;customer&#39; (optional)
      *
-     * @throws \zipMoney\ApiException on non-2xx response
+     * @throws ApiException on non-2xx response
      *
      * @return array of \zipMoney\Model\ChargeCollection, HTTP status code, HTTP response headers (array of strings)
      */
@@ -489,7 +462,7 @@ class ChargesApi
         // for model (json/xml)
         if (isset($_tempBody)) {
             $httpBody = $_tempBody; // $_tempBody is the method argument, if present
-        } elseif (count($formParams) > 0) {
+        } elseif ($formParams !== []) {
             $httpBody = $formParams; // for HTTP post (form)
         }
         // this endpoint requires API key authentication
@@ -512,11 +485,9 @@ class ChargesApi
 
             return [$this->apiClient->getSerializer()->deserialize($response, '\zipMoney\Model\ChargeCollection', $httpHeader), $statusCode, $httpHeader];
         } catch (ApiException $e) {
-            switch ($e->getCode()) {
-                case 200:
-                    $data = $this->apiClient->getSerializer()->deserialize($e->getResponseBody(), '\zipMoney\Model\ChargeCollection', $e->getResponseHeaders());
-                    $e->setResponseObject($data);
-                    break;
+            if ($e->getCode() === 200) {
+                $data = $this->apiClient->getSerializer()->deserialize($e->getResponseBody(), '\zipMoney\Model\ChargeCollection', $e->getResponseHeaders());
+                $e->setResponseObject($data);
             }
 
             throw $e;
@@ -531,9 +502,9 @@ class ChargesApi
      * @param string $id     The id of the charge (required)
      * @param string $expand Allows expanding related entities in the response. Only valid entry is &#39;customer&#39; (optional)
      *
-     * @throws \zipMoney\ApiException on non-2xx response
+     * @throws ApiException on non-2xx response
      *
-     * @return \zipMoney\Model\Charge
+     * @return Charge
      */
     public function chargesRetrieve($id, $expand = null)
     {
@@ -550,7 +521,7 @@ class ChargesApi
      * @param string $id     The id of the charge (required)
      * @param string $expand Allows expanding related entities in the response. Only valid entry is &#39;customer&#39; (optional)
      *
-     * @throws \zipMoney\ApiException on non-2xx response
+     * @throws ApiException on non-2xx response
      *
      * @return array of \zipMoney\Model\Charge, HTTP status code, HTTP response headers (array of strings)
      */
@@ -579,7 +550,7 @@ class ChargesApi
         // path params
         if ($id !== null) {
             $resourcePath = str_replace(
-                '{' . 'id' . '}',
+                '{id}',
                 $this->apiClient->getSerializer()->toPathValue($id),
                 $resourcePath
             );
@@ -590,7 +561,7 @@ class ChargesApi
         // for model (json/xml)
         if (isset($_tempBody)) {
             $httpBody = $_tempBody; // $_tempBody is the method argument, if present
-        } elseif (count($formParams) > 0) {
+        } elseif ($formParams !== []) {
             $httpBody = $formParams; // for HTTP post (form)
         }
         // this endpoint requires API key authentication
@@ -613,11 +584,9 @@ class ChargesApi
 
             return [$this->apiClient->getSerializer()->deserialize($response, '\zipMoney\Model\Charge', $httpHeader), $statusCode, $httpHeader];
         } catch (ApiException $e) {
-            switch ($e->getCode()) {
-                case 200:
-                    $data = $this->apiClient->getSerializer()->deserialize($e->getResponseBody(), '\zipMoney\Model\Charge', $e->getResponseHeaders());
-                    $e->setResponseObject($data);
-                    break;
+            if ($e->getCode() === 200) {
+                $data = $this->apiClient->getSerializer()->deserialize($e->getResponseBody(), '\zipMoney\Model\Charge', $e->getResponseHeaders());
+                $e->setResponseObject($data);
             }
 
             throw $e;

--- a/lib/Api/CheckoutsApi.php
+++ b/lib/Api/CheckoutsApi.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 /**
@@ -14,24 +15,26 @@ namespace zipMoney\Api;
 
 use zipMoney\ApiClient;
 use zipMoney\ApiException;
+use zipMoney\Model\Checkout;
+use zipMoney\Model\CreateCheckoutRequest;
 
 class CheckoutsApi
 {
     /**
      * API Client.
      *
-     * @var \zipMoney\ApiClient instance of the ApiClient
+     * @var ApiClient instance of the ApiClient
      */
-    protected $apiClient;
+    protected ?ApiClient $apiClient;
 
     /**
      * Constructor.
      *
-     * @param null|\zipMoney\ApiClient $apiClient The api client to use
+     * @param null|ApiClient $apiClient The api client to use
      */
-    public function __construct(?\zipMoney\ApiClient $apiClient = null)
+    public function __construct(?ApiClient $apiClient = null)
     {
-        if ($apiClient === null) {
+        if (!$apiClient instanceof ApiClient) {
             $apiClient = new ApiClient();
         }
         $this->apiClient = $apiClient;
@@ -40,9 +43,9 @@ class CheckoutsApi
     /**
      * Get API client.
      *
-     * @return \zipMoney\ApiClient get the API client
+     * @return ApiClient get the API client
      */
-    public function getApiClient()
+    public function getApiClient(): ?ApiClient
     {
         return $this->apiClient;
     }
@@ -50,11 +53,9 @@ class CheckoutsApi
     /**
      * Set the API client.
      *
-     * @param \zipMoney\ApiClient $apiClient set the API client
-     *
-     * @return CheckoutsApi
+     * @param ApiClient $apiClient set the API client
      */
-    public function setApiClient(\zipMoney\ApiClient $apiClient)
+    public function setApiClient(ApiClient $apiClient): static
     {
         $this->apiClient = $apiClient;
 
@@ -66,11 +67,11 @@ class CheckoutsApi
      *
      * Create a checkout
      *
-     * @param \zipMoney\Model\CreateCheckoutRequest $body (optional)
+     * @param CreateCheckoutRequest $body (optional)
      *
-     * @throws \zipMoney\ApiException on non-2xx response
+     * @throws ApiException on non-2xx response
      *
-     * @return \zipMoney\Model\Checkout
+     * @return Checkout
      */
     public function checkoutsCreate($body = null)
     {
@@ -84,9 +85,9 @@ class CheckoutsApi
      *
      * Create a checkout
      *
-     * @param \zipMoney\Model\CreateCheckoutRequest $body (optional)
+     * @param CreateCheckoutRequest $body (optional)
      *
-     * @throws \zipMoney\ApiException on non-2xx response
+     * @throws ApiException on non-2xx response
      *
      * @return array of \zipMoney\Model\Checkout, HTTP status code, HTTP response headers (array of strings)
      */
@@ -116,7 +117,7 @@ class CheckoutsApi
         // for model (json/xml)
         if (isset($_tempBody)) {
             $httpBody = $_tempBody; // $_tempBody is the method argument, if present
-        } elseif (count($formParams) > 0) {
+        } elseif ($formParams !== []) {
             $httpBody = $formParams; // for HTTP post (form)
         }
         // this endpoint requires API key authentication
@@ -145,21 +146,9 @@ class CheckoutsApi
                     $e->setResponseObject($data);
                     break;
                 case 400:
-                    $data = $this->apiClient->getSerializer()->deserialize($e->getResponseBody(), '\zipMoney\Model\ErrorResponse', $e->getResponseHeaders());
-                    $e->setResponseObject($data);
-                    break;
                 case 401:
-                    $data = $this->apiClient->getSerializer()->deserialize($e->getResponseBody(), '\zipMoney\Model\ErrorResponse', $e->getResponseHeaders());
-                    $e->setResponseObject($data);
-                    break;
                 case 402:
-                    $data = $this->apiClient->getSerializer()->deserialize($e->getResponseBody(), '\zipMoney\Model\ErrorResponse', $e->getResponseHeaders());
-                    $e->setResponseObject($data);
-                    break;
                 case 403:
-                    $data = $this->apiClient->getSerializer()->deserialize($e->getResponseBody(), '\zipMoney\Model\ErrorResponse', $e->getResponseHeaders());
-                    $e->setResponseObject($data);
-                    break;
                 case 409:
                     $data = $this->apiClient->getSerializer()->deserialize($e->getResponseBody(), '\zipMoney\Model\ErrorResponse', $e->getResponseHeaders());
                     $e->setResponseObject($data);
@@ -177,9 +166,9 @@ class CheckoutsApi
      *
      * @param string $id (required)
      *
-     * @throws \zipMoney\ApiException on non-2xx response
+     * @throws ApiException on non-2xx response
      *
-     * @return \zipMoney\Model\Checkout
+     * @return Checkout
      */
     public function checkoutsGet($id)
     {
@@ -195,7 +184,7 @@ class CheckoutsApi
      *
      * @param string $id (required)
      *
-     * @throws \zipMoney\ApiException on non-2xx response
+     * @throws ApiException on non-2xx response
      *
      * @return array of \zipMoney\Model\Checkout, HTTP status code, HTTP response headers (array of strings)
      */
@@ -220,7 +209,7 @@ class CheckoutsApi
         // path params
         if ($id !== null) {
             $resourcePath = str_replace(
-                '{' . 'id' . '}',
+                '{id}',
                 $this->apiClient->getSerializer()->toPathValue($id),
                 $resourcePath
             );
@@ -231,7 +220,7 @@ class CheckoutsApi
         // for model (json/xml)
         if (isset($_tempBody)) {
             $httpBody = $_tempBody; // $_tempBody is the method argument, if present
-        } elseif (count($formParams) > 0) {
+        } elseif ($formParams !== []) {
             $httpBody = $formParams; // for HTTP post (form)
         }
         // this endpoint requires API key authentication
@@ -260,17 +249,8 @@ class CheckoutsApi
                     $e->setResponseObject($data);
                     break;
                 case 401:
-                    $data = $this->apiClient->getSerializer()->deserialize($e->getResponseBody(), '\zipMoney\Model\ErrorResponse', $e->getResponseHeaders());
-                    $e->setResponseObject($data);
-                    break;
                 case 403:
-                    $data = $this->apiClient->getSerializer()->deserialize($e->getResponseBody(), '\zipMoney\Model\ErrorResponse', $e->getResponseHeaders());
-                    $e->setResponseObject($data);
-                    break;
                 case 404:
-                    $data = $this->apiClient->getSerializer()->deserialize($e->getResponseBody(), '\zipMoney\Model\ErrorResponse', $e->getResponseHeaders());
-                    $e->setResponseObject($data);
-                    break;
                 case 409:
                     $data = $this->apiClient->getSerializer()->deserialize($e->getResponseBody(), '\zipMoney\Model\ErrorResponse', $e->getResponseHeaders());
                     $e->setResponseObject($data);

--- a/lib/Api/CustomersApi.php
+++ b/lib/Api/CustomersApi.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 /**
@@ -20,18 +21,18 @@ class CustomersApi
     /**
      * API Client.
      *
-     * @var \zipMoney\ApiClient instance of the ApiClient
+     * @var ApiClient instance of the ApiClient
      */
-    protected $apiClient;
+    protected ?ApiClient $apiClient;
 
     /**
      * Constructor.
      *
-     * @param null|\zipMoney\ApiClient $apiClient The api client to use
+     * @param null|ApiClient $apiClient The api client to use
      */
-    public function __construct(?\zipMoney\ApiClient $apiClient = null)
+    public function __construct(?ApiClient $apiClient = null)
     {
-        if ($apiClient === null) {
+        if (!$apiClient instanceof ApiClient) {
             $apiClient = new ApiClient();
         }
         $this->apiClient = $apiClient;
@@ -40,9 +41,9 @@ class CustomersApi
     /**
      * Get API client.
      *
-     * @return \zipMoney\ApiClient get the API client
+     * @return ApiClient get the API client
      */
-    public function getApiClient()
+    public function getApiClient(): ?ApiClient
     {
         return $this->apiClient;
     }
@@ -50,11 +51,9 @@ class CustomersApi
     /**
      * Set the API client.
      *
-     * @param \zipMoney\ApiClient $apiClient set the API client
-     *
-     * @return CustomersApi
+     * @param ApiClient $apiClient set the API client
      */
-    public function setApiClient(\zipMoney\ApiClient $apiClient)
+    public function setApiClient(ApiClient $apiClient): static
     {
         $this->apiClient = $apiClient;
 
@@ -68,7 +67,7 @@ class CustomersApi
      *
      * @param string $id (required)
      *
-     * @throws \zipMoney\ApiException on non-2xx response
+     * @throws ApiException on non-2xx response
      */
     public function customersGet($id)
     {
@@ -84,7 +83,7 @@ class CustomersApi
      *
      * @param string $id (required)
      *
-     * @throws \zipMoney\ApiException on non-2xx response
+     * @throws ApiException on non-2xx response
      *
      * @return array of null, HTTP status code, HTTP response headers (array of strings)
      */
@@ -109,7 +108,7 @@ class CustomersApi
         // path params
         if ($id !== null) {
             $resourcePath = str_replace(
-                '{' . 'id' . '}',
+                '{id}',
                 $this->apiClient->getSerializer()->toPathValue($id),
                 $resourcePath
             );
@@ -120,7 +119,7 @@ class CustomersApi
         // for model (json/xml)
         if (isset($_tempBody)) {
             $httpBody = $_tempBody; // $_tempBody is the method argument, if present
-        } elseif (count($formParams) > 0) {
+        } elseif ($formParams !== []) {
             $httpBody = $formParams; // for HTTP post (form)
         }
 
@@ -150,7 +149,7 @@ class CustomersApi
      *
      * List customers
      *
-     * @throws \zipMoney\ApiException on non-2xx response
+     * @throws ApiException on non-2xx response
      */
     public function customersList()
     {
@@ -164,7 +163,7 @@ class CustomersApi
      *
      * List customers
      *
-     * @throws \zipMoney\ApiException on non-2xx response
+     * @throws ApiException on non-2xx response
      *
      * @return array of null, HTTP status code, HTTP response headers (array of strings)
      */
@@ -188,7 +187,7 @@ class CustomersApi
         // for model (json/xml)
         if (isset($_tempBody)) {
             $httpBody = $_tempBody; // $_tempBody is the method argument, if present
-        } elseif (count($formParams) > 0) {
+        } elseif ($formParams !== []) {
             $httpBody = $formParams; // for HTTP post (form)
         }
 

--- a/lib/Api/RefundsApi.php
+++ b/lib/Api/RefundsApi.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 /**
@@ -14,24 +15,27 @@ namespace zipMoney\Api;
 
 use zipMoney\ApiClient;
 use zipMoney\ApiException;
+use zipMoney\Model\CreateRefundRequest;
+use zipMoney\Model\InlineResponse200;
+use zipMoney\Model\Refund;
 
 class RefundsApi
 {
     /**
      * API Client.
      *
-     * @var \zipMoney\ApiClient instance of the ApiClient
+     * @var ApiClient instance of the ApiClient
      */
-    protected $apiClient;
+    protected ?ApiClient $apiClient;
 
     /**
      * Constructor.
      *
-     * @param null|\zipMoney\ApiClient $apiClient The api client to use
+     * @param null|ApiClient $apiClient The api client to use
      */
-    public function __construct(?\zipMoney\ApiClient $apiClient = null)
+    public function __construct(?ApiClient $apiClient = null)
     {
-        if ($apiClient === null) {
+        if (!$apiClient instanceof ApiClient) {
             $apiClient = new ApiClient();
         }
         $this->apiClient = $apiClient;
@@ -40,9 +44,9 @@ class RefundsApi
     /**
      * Get API client.
      *
-     * @return \zipMoney\ApiClient get the API client
+     * @return ApiClient get the API client
      */
-    public function getApiClient()
+    public function getApiClient(): ?ApiClient
     {
         return $this->apiClient;
     }
@@ -50,11 +54,9 @@ class RefundsApi
     /**
      * Set the API client.
      *
-     * @param \zipMoney\ApiClient $apiClient set the API client
-     *
-     * @return RefundsApi
+     * @param ApiClient $apiClient set the API client
      */
-    public function setApiClient(\zipMoney\ApiClient $apiClient)
+    public function setApiClient(ApiClient $apiClient): static
     {
         $this->apiClient = $apiClient;
 
@@ -66,12 +68,12 @@ class RefundsApi
      *
      * Create a refund
      *
-     * @param \zipMoney\Model\CreateRefundRequest $body            (optional)
+     * @param CreateRefundRequest $body (optional)
      * @param string                              $idempotency_key The unique idempotency key. (optional)
      *
-     * @throws \zipMoney\ApiException on non-2xx response
+     * @throws ApiException on non-2xx response
      *
-     * @return \zipMoney\Model\Refund
+     * @return Refund
      */
     public function refundsCreate($body = null, $idempotency_key = null)
     {
@@ -85,10 +87,10 @@ class RefundsApi
      *
      * Create a refund
      *
-     * @param \zipMoney\Model\CreateRefundRequest $body            (optional)
+     * @param CreateRefundRequest $body (optional)
      * @param string                              $idempotency_key The unique idempotency key. (optional)
      *
-     * @throws \zipMoney\ApiException on non-2xx response
+     * @throws ApiException on non-2xx response
      *
      * @return array of \zipMoney\Model\Refund, HTTP status code, HTTP response headers (array of strings)
      */
@@ -122,7 +124,7 @@ class RefundsApi
         // for model (json/xml)
         if (isset($_tempBody)) {
             $httpBody = $_tempBody; // $_tempBody is the method argument, if present
-        } elseif (count($formParams) > 0) {
+        } elseif ($formParams !== []) {
             $httpBody = $formParams; // for HTTP post (form)
         }
         // this endpoint requires API key authentication
@@ -151,13 +153,7 @@ class RefundsApi
                     $e->setResponseObject($data);
                     break;
                 case 400:
-                    $data = $this->apiClient->getSerializer()->deserialize($e->getResponseBody(), '\zipMoney\Model\ErrorResponse', $e->getResponseHeaders());
-                    $e->setResponseObject($data);
-                    break;
                 case 401:
-                    $data = $this->apiClient->getSerializer()->deserialize($e->getResponseBody(), '\zipMoney\Model\ErrorResponse', $e->getResponseHeaders());
-                    $e->setResponseObject($data);
-                    break;
                 case 402:
                     $data = $this->apiClient->getSerializer()->deserialize($e->getResponseBody(), '\zipMoney\Model\ErrorResponse', $e->getResponseHeaders());
                     $e->setResponseObject($data);
@@ -177,9 +173,9 @@ class RefundsApi
      * @param int    $skip      Number of items to skip when paging (optional, default to 0)
      * @param int    $limit     Number of items to retrieve when paging (optional, default to 100)
      *
-     * @throws \zipMoney\ApiException on non-2xx response
+     * @throws ApiException on non-2xx response
      *
-     * @return \zipMoney\Model\InlineResponse200[]
+     * @return InlineResponse200[]
      */
     public function refundsList($charge_id = null, $skip = null, $limit = null)
     {
@@ -197,7 +193,7 @@ class RefundsApi
      * @param int    $skip      Number of items to skip when paging (optional, default to 0)
      * @param int    $limit     Number of items to retrieve when paging (optional, default to 100)
      *
-     * @throws \zipMoney\ApiException on non-2xx response
+     * @throws ApiException on non-2xx response
      *
      * @return array of \zipMoney\Model\InlineResponse200[], HTTP status code, HTTP response headers (array of strings)
      */
@@ -233,7 +229,7 @@ class RefundsApi
         // for model (json/xml)
         if (isset($_tempBody)) {
             $httpBody = $_tempBody; // $_tempBody is the method argument, if present
-        } elseif (count($formParams) > 0) {
+        } elseif ($formParams !== []) {
             $httpBody = $formParams; // for HTTP post (form)
         }
         // this endpoint requires API key authentication
@@ -256,11 +252,9 @@ class RefundsApi
 
             return [$this->apiClient->getSerializer()->deserialize($response, '\zipMoney\Model\InlineResponse200[]', $httpHeader), $statusCode, $httpHeader];
         } catch (ApiException $e) {
-            switch ($e->getCode()) {
-                case 200:
-                    $data = $this->apiClient->getSerializer()->deserialize($e->getResponseBody(), '\zipMoney\Model\InlineResponse200[]', $e->getResponseHeaders());
-                    $e->setResponseObject($data);
-                    break;
+            if ($e->getCode() === 200) {
+                $data = $this->apiClient->getSerializer()->deserialize($e->getResponseBody(), '\zipMoney\Model\InlineResponse200[]', $e->getResponseHeaders());
+                $e->setResponseObject($data);
             }
 
             throw $e;
@@ -274,9 +268,9 @@ class RefundsApi
      *
      * @param string $id The id of the refund (required)
      *
-     * @throws \zipMoney\ApiException on non-2xx response
+     * @throws ApiException on non-2xx response
      *
-     * @return \zipMoney\Model\Refund
+     * @return Refund
      */
     public function refundsRetrieve($id)
     {
@@ -292,7 +286,7 @@ class RefundsApi
      *
      * @param string $id The id of the refund (required)
      *
-     * @throws \zipMoney\ApiException on non-2xx response
+     * @throws ApiException on non-2xx response
      *
      * @return array of \zipMoney\Model\Refund, HTTP status code, HTTP response headers (array of strings)
      */
@@ -317,7 +311,7 @@ class RefundsApi
         // path params
         if ($id !== null) {
             $resourcePath = str_replace(
-                '{' . 'id' . '}',
+                '{id}',
                 $this->apiClient->getSerializer()->toPathValue($id),
                 $resourcePath
             );
@@ -328,7 +322,7 @@ class RefundsApi
         // for model (json/xml)
         if (isset($_tempBody)) {
             $httpBody = $_tempBody; // $_tempBody is the method argument, if present
-        } elseif (count($formParams) > 0) {
+        } elseif ($formParams !== []) {
             $httpBody = $formParams; // for HTTP post (form)
         }
         // this endpoint requires API key authentication
@@ -351,11 +345,9 @@ class RefundsApi
 
             return [$this->apiClient->getSerializer()->deserialize($response, '\zipMoney\Model\Refund', $httpHeader), $statusCode, $httpHeader];
         } catch (ApiException $e) {
-            switch ($e->getCode()) {
-                case 200:
-                    $data = $this->apiClient->getSerializer()->deserialize($e->getResponseBody(), '\zipMoney\Model\Refund', $e->getResponseHeaders());
-                    $e->setResponseObject($data);
-                    break;
+            if ($e->getCode() === 200) {
+                $data = $this->apiClient->getSerializer()->deserialize($e->getResponseBody(), '\zipMoney\Model\Refund', $e->getResponseHeaders());
+                $e->setResponseObject($data);
             }
 
             throw $e;

--- a/lib/Api/SettlementsApi.php
+++ b/lib/Api/SettlementsApi.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 /**
@@ -14,24 +15,25 @@ namespace zipMoney\Api;
 
 use zipMoney\ApiClient;
 use zipMoney\ApiException;
+use zipMoney\Model\Settlement;
 
 class SettlementsApi
 {
     /**
      * API Client.
      *
-     * @var \zipMoney\ApiClient instance of the ApiClient
+     * @var ApiClient instance of the ApiClient
      */
-    protected $apiClient;
+    protected ?ApiClient $apiClient;
 
     /**
      * Constructor.
      *
-     * @param null|\zipMoney\ApiClient $apiClient The api client to use
+     * @param null|ApiClient $apiClient The api client to use
      */
-    public function __construct(?\zipMoney\ApiClient $apiClient = null)
+    public function __construct(?ApiClient $apiClient = null)
     {
-        if ($apiClient === null) {
+        if (!$apiClient instanceof ApiClient) {
             $apiClient = new ApiClient();
         }
         $this->apiClient = $apiClient;
@@ -40,9 +42,9 @@ class SettlementsApi
     /**
      * Get API client.
      *
-     * @return \zipMoney\ApiClient get the API client
+     * @return ApiClient get the API client
      */
-    public function getApiClient()
+    public function getApiClient(): ?ApiClient
     {
         return $this->apiClient;
     }
@@ -50,11 +52,9 @@ class SettlementsApi
     /**
      * Set the API client.
      *
-     * @param \zipMoney\ApiClient $apiClient set the API client
-     *
-     * @return SettlementsApi
+     * @param ApiClient $apiClient set the API client
      */
-    public function setApiClient(\zipMoney\ApiClient $apiClient)
+    public function setApiClient(ApiClient $apiClient): static
     {
         $this->apiClient = $apiClient;
 
@@ -68,9 +68,9 @@ class SettlementsApi
      *
      * @param string $id The settlement id (required)
      *
-     * @throws \zipMoney\ApiException on non-2xx response
+     * @throws ApiException on non-2xx response
      *
-     * @return \zipMoney\Model\Settlement
+     * @return Settlement
      */
     public function settlementsGet($id)
     {
@@ -86,7 +86,7 @@ class SettlementsApi
      *
      * @param string $id The settlement id (required)
      *
-     * @throws \zipMoney\ApiException on non-2xx response
+     * @throws ApiException on non-2xx response
      *
      * @return array of \zipMoney\Model\Settlement, HTTP status code, HTTP response headers (array of strings)
      */
@@ -111,7 +111,7 @@ class SettlementsApi
         // path params
         if ($id !== null) {
             $resourcePath = str_replace(
-                '{' . 'id' . '}',
+                '{id}',
                 $this->apiClient->getSerializer()->toPathValue($id),
                 $resourcePath
             );
@@ -122,7 +122,7 @@ class SettlementsApi
         // for model (json/xml)
         if (isset($_tempBody)) {
             $httpBody = $_tempBody; // $_tempBody is the method argument, if present
-        } elseif (count($formParams) > 0) {
+        } elseif ($formParams !== []) {
             $httpBody = $formParams; // for HTTP post (form)
         }
 
@@ -146,9 +146,6 @@ class SettlementsApi
                     $e->setResponseObject($data);
                     break;
                 case 400:
-                    $data = $this->apiClient->getSerializer()->deserialize($e->getResponseBody(), '\zipMoney\Model\ErrorResponse', $e->getResponseHeaders());
-                    $e->setResponseObject($data);
-                    break;
                 case 404:
                     $data = $this->apiClient->getSerializer()->deserialize($e->getResponseBody(), '\zipMoney\Model\ErrorResponse', $e->getResponseHeaders());
                     $e->setResponseObject($data);
@@ -164,7 +161,7 @@ class SettlementsApi
      *
      * List settlements
      *
-     * @throws \zipMoney\ApiException on non-2xx response
+     * @throws ApiException on non-2xx response
      */
     public function settlementsList()
     {
@@ -178,7 +175,7 @@ class SettlementsApi
      *
      * List settlements
      *
-     * @throws \zipMoney\ApiException on non-2xx response
+     * @throws ApiException on non-2xx response
      *
      * @return array of null, HTTP status code, HTTP response headers (array of strings)
      */
@@ -202,7 +199,7 @@ class SettlementsApi
         // for model (json/xml)
         if (isset($_tempBody)) {
             $httpBody = $_tempBody; // $_tempBody is the method argument, if present
-        } elseif (count($formParams) > 0) {
+        } elseif ($formParams !== []) {
             $httpBody = $formParams; // for HTTP post (form)
         }
 

--- a/lib/Api/TokensApi.php
+++ b/lib/Api/TokensApi.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 /**
@@ -14,24 +15,26 @@ namespace zipMoney\Api;
 
 use zipMoney\ApiClient;
 use zipMoney\ApiException;
+use zipMoney\Model\CreateTokenRequest;
+use zipMoney\Model\Token;
 
 class TokensApi
 {
     /**
      * API Client.
      *
-     * @var \zipMoney\ApiClient instance of the ApiClient
+     * @var ApiClient instance of the ApiClient
      */
-    protected $apiClient;
+    protected ?ApiClient $apiClient;
 
     /**
      * Constructor.
      *
-     * @param null|\zipMoney\ApiClient $apiClient The api client to use
+     * @param null|ApiClient $apiClient The api client to use
      */
-    public function __construct(?\zipMoney\ApiClient $apiClient = null)
+    public function __construct(?ApiClient $apiClient = null)
     {
-        if ($apiClient === null) {
+        if (!$apiClient instanceof ApiClient) {
             $apiClient = new ApiClient();
         }
         $this->apiClient = $apiClient;
@@ -40,9 +43,9 @@ class TokensApi
     /**
      * Get API client.
      *
-     * @return \zipMoney\ApiClient get the API client
+     * @return ApiClient get the API client
      */
-    public function getApiClient()
+    public function getApiClient(): ?ApiClient
     {
         return $this->apiClient;
     }
@@ -50,11 +53,9 @@ class TokensApi
     /**
      * Set the API client.
      *
-     * @param \zipMoney\ApiClient $apiClient set the API client
-     *
-     * @return TokensApi
+     * @param ApiClient $apiClient set the API client
      */
-    public function setApiClient(\zipMoney\ApiClient $apiClient)
+    public function setApiClient(ApiClient $apiClient): static
     {
         $this->apiClient = $apiClient;
 
@@ -66,12 +67,12 @@ class TokensApi
      *
      * Create token
      *
-     * @param \zipMoney\Model\CreateTokenRequest $body            (optional)
+     * @param CreateTokenRequest $body (optional)
      * @param string                             $idempotency_key The unique idempotency key. (optional)
      *
-     * @throws \zipMoney\ApiException on non-2xx response
+     * @throws ApiException on non-2xx response
      *
-     * @return \zipMoney\Model\Token
+     * @return Token
      */
     public function tokensCreate($body = null, $idempotency_key = null)
     {
@@ -85,10 +86,10 @@ class TokensApi
      *
      * Create token
      *
-     * @param \zipMoney\Model\CreateTokenRequest $body            (optional)
+     * @param CreateTokenRequest $body (optional)
      * @param string                             $idempotency_key The unique idempotency key. (optional)
      *
-     * @throws \zipMoney\ApiException on non-2xx response
+     * @throws ApiException on non-2xx response
      *
      * @return array of \zipMoney\Model\Token, HTTP status code, HTTP response headers (array of strings)
      */
@@ -122,7 +123,7 @@ class TokensApi
         // for model (json/xml)
         if (isset($_tempBody)) {
             $httpBody = $_tempBody; // $_tempBody is the method argument, if present
-        } elseif (count($formParams) > 0) {
+        } elseif ($formParams !== []) {
             $httpBody = $formParams; // for HTTP post (form)
         }
         // this endpoint requires API key authentication
@@ -151,17 +152,8 @@ class TokensApi
                     $e->setResponseObject($data);
                     break;
                 case 401:
-                    $data = $this->apiClient->getSerializer()->deserialize($e->getResponseBody(), '\zipMoney\Model\ErrorResponse', $e->getResponseHeaders());
-                    $e->setResponseObject($data);
-                    break;
                 case 402:
-                    $data = $this->apiClient->getSerializer()->deserialize($e->getResponseBody(), '\zipMoney\Model\ErrorResponse', $e->getResponseHeaders());
-                    $e->setResponseObject($data);
-                    break;
                 case 403:
-                    $data = $this->apiClient->getSerializer()->deserialize($e->getResponseBody(), '\zipMoney\Model\ErrorResponse', $e->getResponseHeaders());
-                    $e->setResponseObject($data);
-                    break;
                 case 409:
                     $data = $this->apiClient->getSerializer()->deserialize($e->getResponseBody(), '\zipMoney\Model\ErrorResponse', $e->getResponseHeaders());
                     $e->setResponseObject($data);

--- a/lib/ApiClient.php
+++ b/lib/ApiClient.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 /**
@@ -30,26 +31,22 @@ class ApiClient
 
     /**
      * Configuration.
-     *
-     * @var Configuration
      */
-    protected $config;
+    protected ?Configuration $config;
 
     /**
      * Object Serializer.
-     *
-     * @var ObjectSerializer
      */
-    protected $serializer;
+    protected ObjectSerializer $serializer;
 
     /**
      * Constructor of the class.
      *
      * @param null|Configuration $config config for this ApiClient
      */
-    public function __construct(?\zipMoney\Configuration $config = null)
+    public function __construct(?Configuration $config = null)
     {
-        if ($config === null) {
+        if (!$config instanceof Configuration) {
             $config = Configuration::getDefaultConfiguration();
         }
 
@@ -65,17 +62,15 @@ class ApiClient
      *
      * @return Configuration
      */
-    public function getConfig()
+    public function getConfig(): ?Configuration
     {
         return $this->config;
     }
 
     /**
      * Get the serializer.
-     *
-     * @return ObjectSerializer
      */
-    public function getSerializer()
+    public function getSerializer(): ObjectSerializer
     {
         return $this->serializer;
     }
@@ -87,7 +82,7 @@ class ApiClient
      *
      * @return string API key with the prefix
      */
-    public function getApiKeyWithPrefix($apiKeyIdentifier)
+    public function getApiKeyWithPrefix($apiKeyIdentifier): ?string
     {
         $prefix = $this->config->getApiKeyPrefix($apiKeyIdentifier);
         $apiKey = $this->config->getApiKey($apiKeyIdentifier);
@@ -96,13 +91,7 @@ class ApiClient
             return null;
         }
 
-        if (isset($prefix)) {
-            $keyWithPrefix = $prefix . ' ' . $apiKey;
-        } else {
-            $keyWithPrefix = $apiKey;
-        }
-
-        return $keyWithPrefix;
+        return isset($prefix) ? $prefix . ' ' . $apiKey : $apiKey;
     }
 
     /**
@@ -116,11 +105,11 @@ class ApiClient
      * @param string $responseType expected response type of the endpoint
      * @param string $endpointPath path to method endpoint before expanding parameters
      *
-     * @throws \zipMoney\ApiException on a non 2xx response
+     * @throws ApiException on a non 2xx response
      *
-     * @return mixed
+     * @return mixed[]
      */
-    public function callApi($resourcePath, $method, $queryParams, $postData, $headerParams, $responseType = null, $endpointPath = null)
+    public function callApi(string $resourcePath, string $method, $queryParams, $postData, $headerParams, $responseType = null, $endpointPath = null): array
     {
         $headers = [];
 
@@ -135,10 +124,10 @@ class ApiClient
         }
 
         // form data
-        if ($postData and in_array('Content-Type: application/x-www-form-urlencoded', $headers, true)) {
+        if ($postData && in_array('Content-Type: application/x-www-form-urlencoded', $headers, true)) {
             $postData = http_build_query($postData);
-        } elseif ((is_object($postData) or is_array($postData)) and !in_array('Content-Type: multipart/form-data', $headers, true)) { // json model
-            $postData = json_encode(\zipMoney\ObjectSerializer::sanitizeForSerialization($postData));
+        } elseif ((is_object($postData) || is_array($postData)) && !in_array('Content-Type: multipart/form-data', $headers, true)) { // json model
+            $postData = json_encode(ObjectSerializer::sanitizeForSerialization($postData));
         }
 
         $url = $this->config->getHost() . $resourcePath;
@@ -215,7 +204,7 @@ class ApiClient
         // obtain the HTTP response headers
         curl_setopt($curl, CURLOPT_HEADER, 1);
 
-        $num_retries = $this->config->getCurlNumRetries() ? $this->config->getCurlNumRetries() : 0;
+        $num_retries = $this->config->getCurlNumRetries() ?: 0;
         $count = 0;
 
         do {
@@ -232,7 +221,7 @@ class ApiClient
             $count++;
             $msg = curl_error($curl);
         } while (($count <= $num_retries) &&
-                  ($response_info['http_code'] === 0 && empty($msg)) &&
+                  ($response_info['http_code'] === 0 && ($msg === '' || $msg === '0')) &&
                   !empty($headerParams['Idempotency-Key']));
 
         // Handle the response
@@ -240,7 +229,7 @@ class ApiClient
             $curl_error_message = curl_error($curl);
 
             // curl_exec can sometimes fail but still return a blank message from curl_error().
-            if (!empty($curl_error_message)) {
+            if ($curl_error_message !== '' && $curl_error_message !== '0') {
                 $error_message = "API call to {$url} failed: {$curl_error_message}";
             } else {
                 $error_message = "API call to {$url} failed, but for an unknown reason. " .
@@ -285,9 +274,9 @@ class ApiClient
      *
      * @return string Accept (e.g. application/json)
      */
-    public function selectHeaderAccept($accept)
+    public function selectHeaderAccept(array $accept): ?string
     {
-        if (count($accept) === 0 or (count($accept) === 1 and $accept[0] === '')) {
+        if ($accept === [] || count($accept) === 1 && $accept[0] === '') {
             return null;
         }
         if (preg_grep('/application\\/json/i', $accept)) {
@@ -304,9 +293,9 @@ class ApiClient
      *
      * @return string Content-Type (e.g. application/json)
      */
-    public function selectHeaderContentType($content_type)
+    public function selectHeaderContentType(array $content_type): string
     {
-        if (count($content_type) === 0 or (count($content_type) === 1 and $content_type[0] === '')) {
+        if ($content_type === [] || count($content_type) === 1 && $content_type[0] === '') {
             return 'application/json';
         }
         if (preg_grep('/application\\/json/i', $content_type)) {
@@ -323,7 +312,7 @@ class ApiClient
      *
      * @return string[] Array of HTTP response heaers
      */
-    protected function httpParseHeaders($raw_headers)
+    protected function httpParseHeaders($raw_headers): array
     {
         // ref/credit: http://php.net/manual/en/function.http-parse-headers.php#112986
         $headers = [];
@@ -338,14 +327,14 @@ class ApiClient
                 } elseif (is_array($headers[$h[0]])) {
                     $headers[$h[0]] = array_merge($headers[$h[0]], [trim($h[1])]);
                 } else {
-                    $headers[$h[0]] = array_merge([$headers[$h[0]]], [trim($h[1])]);
+                    $headers[$h[0]] = [$headers[$h[0]], trim($h[1])];
                 }
 
                 $key = $h[0];
             } else {
-                if (substr($h[0], 0, 1) === "\t") {
+                if (str_starts_with($h[0], "\t")) {
                     $headers[$key] .= "\r\n\t" . trim($h[0]);
-                } elseif (!$key) {
+                } elseif ($key === '' || $key === '0') {
                     $headers[0] = trim($h[0]);
                 }
                 trim($h[0]);
@@ -355,7 +344,7 @@ class ApiClient
         return $headers;
     }
 
-    protected function generateErrorMessage($response)
+    protected function generateErrorMessage($response): string
     {
         $errorMessage = 'An error occurred while processing payment';
 

--- a/lib/ApiException.php
+++ b/lib/ApiException.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 /**
@@ -17,20 +18,6 @@ use Exception;
 class ApiException extends Exception
 {
     /**
-     * The HTTP body of the server response either as Json or string.
-     *
-     * @var mixed
-     */
-    protected $responseBody;
-
-    /**
-     * The HTTP header of the server response.
-     *
-     * @var string[]
-     */
-    protected $responseHeaders;
-
-    /**
      * The deserialized response object.
      *
      * @var;
@@ -45,11 +32,15 @@ class ApiException extends Exception
      * @param string $responseHeaders HTTP response header
      * @param mixed  $responseBody    HTTP body of the server response either as Json or string
      */
-    public function __construct($message = '', $code = 0, $responseHeaders = null, $responseBody = null)
+    public function __construct($message = '', $code = 0, /**
+     * The HTTP header of the server response.
+     */
+        protected $responseHeaders = null, /**
+     * The HTTP body of the server response either as Json or string.
+     */
+        protected mixed $responseBody = null)
     {
         parent::__construct($message, $code);
-        $this->responseHeaders = $responseHeaders;
-        $this->responseBody = $responseBody;
     }
 
     /**
@@ -77,7 +68,7 @@ class ApiException extends Exception
      *
      * @param mixed $obj Deserialized response object
      */
-    public function setResponseObject($obj)
+    public function setResponseObject(mixed $obj): void
     {
         $this->responseObject = $obj;
     }

--- a/lib/Configuration.php
+++ b/lib/Configuration.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 /**
@@ -14,7 +15,7 @@ namespace zipMoney;
 
 class Configuration
 {
-    private static $defaultConfiguration;
+    private static ?\zipMoney\Configuration $defaultConfiguration = null;
 
     /**
      * Associate array to store API key(s).
@@ -147,10 +148,8 @@ class Configuration
 
     /**
      * Debug file location (log to STDOUT by default).
-     *
-     * @var string
      */
-    protected $tempFolderPath;
+    protected string $tempFolderPath;
 
     /**
      * Indicates if SSL verification should be enabled or disabled.
@@ -211,10 +210,8 @@ class Configuration
      *
      * @param string $apiKeyIdentifier API key identifier (authentication scheme)
      * @param string $key              API key or token
-     *
-     * @return Configuration
      */
-    public function setApiKey($apiKeyIdentifier, $key)
+    public function setApiKey($apiKeyIdentifier, $key): static
     {
         $this->apiKeys[$apiKeyIdentifier] = $key;
 
@@ -230,7 +227,7 @@ class Configuration
      */
     public function getApiKey($apiKeyIdentifier)
     {
-        return isset($this->apiKeys[$apiKeyIdentifier]) ? $this->apiKeys[$apiKeyIdentifier] : null;
+        return $this->apiKeys[$apiKeyIdentifier] ?? null;
     }
 
     /**
@@ -238,10 +235,8 @@ class Configuration
      *
      * @param string $apiKeyIdentifier API key identifier (authentication scheme)
      * @param string $prefix           API key prefix, e.g. Bearer
-     *
-     * @return Configuration
      */
-    public function setApiKeyPrefix($apiKeyIdentifier, $prefix)
+    public function setApiKeyPrefix($apiKeyIdentifier, $prefix): static
     {
         $this->apiKeyPrefixes[$apiKeyIdentifier] = $prefix;
 
@@ -257,17 +252,15 @@ class Configuration
      */
     public function getApiKeyPrefix($apiKeyIdentifier)
     {
-        return isset($this->apiKeyPrefixes[$apiKeyIdentifier]) ? $this->apiKeyPrefixes[$apiKeyIdentifier] : null;
+        return $this->apiKeyPrefixes[$apiKeyIdentifier] ?? null;
     }
 
     /**
      * Sets the access token for OAuth.
      *
      * @param string $accessToken Token for OAuth
-     *
-     * @return Configuration
      */
-    public function setAccessToken($accessToken)
+    public function setAccessToken($accessToken): static
     {
         $this->accessToken = $accessToken;
 
@@ -288,10 +281,8 @@ class Configuration
      * Sets the username for HTTP basic authentication.
      *
      * @param string $username Username for HTTP basic authentication
-     *
-     * @return Configuration
      */
-    public function setUsername($username)
+    public function setUsername($username): static
     {
         $this->username = $username;
 
@@ -312,10 +303,8 @@ class Configuration
      * Sets the password for HTTP basic authentication.
      *
      * @param string $password Password for HTTP basic authentication
-     *
-     * @return Configuration
      */
-    public function setPassword($password)
+    public function setPassword($password): static
     {
         $this->password = $password;
 
@@ -337,10 +326,8 @@ class Configuration
      *
      * @param string $headerName  header name (e.g. Token)
      * @param string $headerValue header value (e.g. 1z8wp3)
-     *
-     * @return Configuration
      */
-    public function addDefaultHeader($headerName, $headerValue)
+    public function addDefaultHeader($headerName, $headerValue): static
     {
         if (!is_string($headerName)) {
             throw new \InvalidArgumentException('Header name must be a string.');
@@ -365,8 +352,6 @@ class Configuration
      * Deletes a default header.
      *
      * @param string $headerName the header to delete
-     *
-     * @return Configuration
      */
     public function deleteDefaultHeader($headerName): void
     {
@@ -377,10 +362,8 @@ class Configuration
      * Sets the host.
      *
      * @param string $host Host
-     *
-     * @return Configuration
      */
-    public function setHost($host)
+    public function setHost($host): static
     {
         $this->host = $host;
 
@@ -401,10 +384,8 @@ class Configuration
      * Sets the user agent of the api client.
      *
      * @param string $userAgent the user agent of the api client
-     *
-     * @return Configuration
      */
-    public function setUserAgent($userAgent)
+    public function setUserAgent($userAgent): static
     {
         if (!is_string($userAgent)) {
             throw new \InvalidArgumentException('User-agent must be a string.');
@@ -429,10 +410,8 @@ class Configuration
      * Sets the HTTP timeout value.
      *
      * @param int $seconds Number of seconds before timing out [set to 0 for no timeout]
-     *
-     * @return Configuration
      */
-    public function setCurlTimeout($seconds)
+    public function setCurlTimeout($seconds): static
     {
         if (!is_numeric($seconds) || $seconds < 0) {
             throw new \InvalidArgumentException('Timeout value must be numeric and a non-negative number.');
@@ -457,11 +436,9 @@ class Configuration
      * Sets the retry value.
      *
      * @param int  Number of retries before it gives up
-     * @param mixed $retries
      *
-     * @return Configuration
      */
-    public function setCurlNumRetries($retries)
+    public function setCurlNumRetries(mixed $retries): static
     {
         if (!is_numeric($retries) || $retries < 0) {
             throw new \InvalidArgumentException('Retries value must be numeric and a non-negative number.');
@@ -486,10 +463,8 @@ class Configuration
      * Sets the HTTP connect timeout value.
      *
      * @param int $seconds Number of seconds before connection times out [set to 0 for no timeout]
-     *
-     * @return Configuration
      */
-    public function setCurlConnectTimeout($seconds)
+    public function setCurlConnectTimeout($seconds): static
     {
         if (!is_numeric($seconds) || $seconds < 0) {
             throw new \InvalidArgumentException('Connect timeout value must be numeric and a non-negative number.');
@@ -514,10 +489,8 @@ class Configuration
      * Sets the Retry Interval Value.
      *
      * @param int $retryInterval HTTP Proxy Port
-     *
-     * @return Configuration
      */
-    public function setRetryInterval($retryInterval)
+    public function setRetryInterval($retryInterval): static
     {
         $this->retryInterval = $retryInterval;
 
@@ -538,10 +511,8 @@ class Configuration
      * Sets the HTTP Proxy Host.
      *
      * @param string $proxyHost HTTP Proxy URL
-     *
-     * @return Configuration
      */
-    public function setCurlProxyHost($proxyHost)
+    public function setCurlProxyHost($proxyHost): static
     {
         $this->proxyHost = $proxyHost;
 
@@ -562,10 +533,8 @@ class Configuration
      * Sets the HTTP Proxy Port.
      *
      * @param int $proxyPort HTTP Proxy Port
-     *
-     * @return Configuration
      */
-    public function setCurlProxyPort($proxyPort)
+    public function setCurlProxyPort($proxyPort): static
     {
         $this->proxyPort = $proxyPort;
 
@@ -586,10 +555,8 @@ class Configuration
      * Sets the HTTP Proxy Type.
      *
      * @param int $proxyType HTTP Proxy Type
-     *
-     * @return Configuration
      */
-    public function setCurlProxyType($proxyType)
+    public function setCurlProxyType($proxyType): static
     {
         $this->proxyType = $proxyType;
 
@@ -610,10 +577,8 @@ class Configuration
      * Sets the HTTP Proxy User.
      *
      * @param string $proxyUser HTTP Proxy User
-     *
-     * @return Configuration
      */
-    public function setCurlProxyUser($proxyUser)
+    public function setCurlProxyUser($proxyUser): static
     {
         $this->proxyUser = $proxyUser;
 
@@ -634,10 +599,8 @@ class Configuration
      * Sets the HTTP Proxy Password.
      *
      * @param string $proxyPassword HTTP Proxy Password
-     *
-     * @return Configuration
      */
-    public function setCurlProxyPassword($proxyPassword)
+    public function setCurlProxyPassword($proxyPassword): static
     {
         $this->proxyPassword = $proxyPassword;
 
@@ -658,10 +621,8 @@ class Configuration
      * Sets debug flag.
      *
      * @param bool $debug Debug flag
-     *
-     * @return Configuration
      */
-    public function setDebug($debug)
+    public function setDebug($debug): static
     {
         $this->debug = $debug;
 
@@ -682,10 +643,8 @@ class Configuration
      * Sets the environment.
      *
      * @param bool $environment
-     *
-     * @return Configuration
      */
-    public function setEnvironment($environment)
+    public function setEnvironment($environment): static
     {
         $this->environment = $environment;
 
@@ -714,10 +673,8 @@ class Configuration
      * Sets the debug file.
      *
      * @param string $debugFile Debug file
-     *
-     * @return Configuration
      */
-    public function setDebugFile($debugFile)
+    public function setDebugFile($debugFile): static
     {
         $this->debugFile = $debugFile;
 
@@ -738,10 +695,8 @@ class Configuration
      * Sets the temp folder path.
      *
      * @param string $tempFolderPath Temp folder path
-     *
-     * @return Configuration
      */
-    public function setTempFolderPath($tempFolderPath)
+    public function setTempFolderPath(string $tempFolderPath): static
     {
         $this->tempFolderPath = $tempFolderPath;
 
@@ -753,7 +708,7 @@ class Configuration
      *
      * @return string Temp folder path
      */
-    public function getTempFolderPath()
+    public function getTempFolderPath(): string
     {
         return $this->tempFolderPath;
     }
@@ -762,10 +717,8 @@ class Configuration
      * Sets if SSL verification should be enabled or disabled.
      *
      * @param bool $sslVerification True if the certificate should be validated, false otherwise
-     *
-     * @return Configuration
      */
-    public function setSSLVerification($sslVerification)
+    public function setSSLVerification($sslVerification): static
     {
         $this->sslVerification = $sslVerification;
 
@@ -784,12 +737,10 @@ class Configuration
 
     /**
      * Gets the default configuration instance.
-     *
-     * @return Configuration
      */
-    public static function getDefaultConfiguration()
+    public static function getDefaultConfiguration(): \zipMoney\Configuration
     {
-        if (self::$defaultConfiguration === null) {
+        if (!self::$defaultConfiguration instanceof \zipMoney\Configuration) {
             self::$defaultConfiguration = new Configuration();
         }
 
@@ -801,7 +752,7 @@ class Configuration
      *
      * @param Configuration $config An instance of the Configuration Object
      */
-    public static function setDefaultConfiguration(Configuration $config)
+    public static function setDefaultConfiguration(Configuration $config): void
     {
         self::$defaultConfiguration = $config;
     }
@@ -811,25 +762,22 @@ class Configuration
      *
      * @return string The report for debugging
      */
-    public static function toDebugReport()
+    public static function toDebugReport(): string
     {
         $report = 'PHP SDK (zipMoney) Debug Report:' . PHP_EOL;
         $report .= '    OS: ' . php_uname() . PHP_EOL;
         $report .= '    PHP Version: ' . phpversion() . PHP_EOL;
         $report .= '    OpenAPI Spec Version: 2017-03-01' . PHP_EOL;
-        $report .= '    Temp Folder Path: ' . self::getDefaultConfiguration()->getTempFolderPath() . PHP_EOL;
 
-        return $report;
+        return $report . ('    Temp Folder Path: ' . self::getDefaultConfiguration()->getTempFolderPath() . PHP_EOL);
     }
 
     /**
      * Sets the platform the library is being used.
      *
      * @param string $platform
-     *
-     * @return Configuration
      */
-    public function setPlatform($platform)
+    public function setPlatform($platform): static
     {
         $this->platform = $platform;
 
@@ -849,18 +797,16 @@ class Configuration
     /**
      * Add the api version.
      *
-     * @param mixed $version
      *
-     * @return Configuration
      */
-    public function setApiVersion($version)
+    public function setApiVersion(mixed $version): static
     {
         $this->defaultHeaders['Zip-Version'] = $version;
 
         return $this;
     }
 
-    public function setDefaultHeaders()
+    public function setDefaultHeaders(): void
     {
         $user_agent_array = [];
 
@@ -889,7 +835,13 @@ class Configuration
      */
     public function getPackageVersion()
     {
-        $package_config = file_get_contents(dirname(__FILE__) . './../composer.json');
+        $package_config_path = __DIR__ . '/../composer.json';
+
+        if (!is_file($package_config_path) || !is_readable($package_config_path)) {
+            return null;
+        }
+
+        $package_config = file_get_contents($package_config_path);
 
         if ($package_config) {
             $package_config_object = json_decode($package_config);

--- a/lib/Model/Address.php
+++ b/lib/Model/Address.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 /**
@@ -13,8 +14,9 @@ declare(strict_types=1);
 namespace zipMoney\Model;
 
 use ArrayAccess;
+use zipMoney\ObjectSerializer;
 
-class Address implements ArrayAccess
+class Address implements ArrayAccess, \Stringable
 {
     public const DISCRIMINATOR = 'subclass';
 
@@ -123,14 +125,14 @@ class Address implements ArrayAccess
      */
     public function __construct(?array $data = null)
     {
-        $this->container['line1'] = isset($data['line1']) ? $data['line1'] : null;
-        $this->container['line2'] = isset($data['line2']) ? $data['line2'] : null;
-        $this->container['city'] = isset($data['city']) ? $data['city'] : null;
-        $this->container['state'] = isset($data['state']) ? $data['state'] : null;
-        $this->container['postal_code'] = isset($data['postal_code']) ? $data['postal_code'] : null;
-        $this->container['country'] = isset($data['country']) ? $data['country'] : null;
-        $this->container['first_name'] = isset($data['first_name']) ? $data['first_name'] : null;
-        $this->container['last_name'] = isset($data['last_name']) ? $data['last_name'] : null;
+        $this->container['line1'] = $data['line1'] ?? null;
+        $this->container['line2'] = $data['line2'] ?? null;
+        $this->container['city'] = $data['city'] ?? null;
+        $this->container['state'] = $data['state'] ?? null;
+        $this->container['postal_code'] = $data['postal_code'] ?? null;
+        $this->container['country'] = $data['country'] ?? null;
+        $this->container['first_name'] = $data['first_name'] ?? null;
+        $this->container['last_name'] = $data['last_name'] ?? null;
     }
 
     /**
@@ -138,7 +140,7 @@ class Address implements ArrayAccess
      *
      * @return array invalid properties with reasons
      */
-    public function listInvalidProperties()
+    public function listInvalidProperties(): array
     {
         $invalid_properties = [];
 
@@ -236,11 +238,7 @@ class Address implements ArrayAccess
         if (strlen($this->container['country']) < 2) {
             return false;
         }
-        if (strlen($this->container['first_name']) > 200) {
-            return false;
-        }
-
-        return true;
+        return strlen($this->container['first_name']) <= 200;
     }
 
     /**
@@ -260,7 +258,7 @@ class Address implements ArrayAccess
      *
      * @return $this
      */
-    public function setLine1($line1)
+    public function setLine1($line1): static
     {
         if ((strlen($line1) > 200)) {
             throw new \InvalidArgumentException('invalid length for $line1 when calling Address., must be smaller than or equal to 200.');
@@ -288,7 +286,7 @@ class Address implements ArrayAccess
      *
      * @return $this
      */
-    public function setLine2($line2)
+    public function setLine2($line2): static
     {
         if (!is_null($line2) && (strlen($line2) > 200)) {
             throw new \InvalidArgumentException('invalid length for $line2 when calling Address., must be smaller than or equal to 200.');
@@ -316,7 +314,7 @@ class Address implements ArrayAccess
      *
      * @return $this
      */
-    public function setCity($city)
+    public function setCity($city): static
     {
         if ((strlen($city) > 50)) {
             throw new \InvalidArgumentException('invalid length for $city when calling Address., must be smaller than or equal to 50.');
@@ -344,7 +342,7 @@ class Address implements ArrayAccess
      *
      * @return $this
      */
-    public function setState($state)
+    public function setState($state): static
     {
         if ((strlen($state) > 50)) {
             throw new \InvalidArgumentException('invalid length for $state when calling Address., must be smaller than or equal to 50.');
@@ -372,7 +370,7 @@ class Address implements ArrayAccess
      *
      * @return $this
      */
-    public function setPostalCode($postal_code)
+    public function setPostalCode($postal_code): static
     {
         if ((strlen($postal_code) > 15)) {
             throw new \InvalidArgumentException('invalid length for $postal_code when calling Address., must be smaller than or equal to 15.');
@@ -400,7 +398,7 @@ class Address implements ArrayAccess
      *
      * @return $this
      */
-    public function setCountry($country)
+    public function setCountry($country): static
     {
         if ((strlen($country) > 2)) {
             throw new \InvalidArgumentException('invalid length for $country when calling Address., must be smaller than or equal to 2.');
@@ -431,7 +429,7 @@ class Address implements ArrayAccess
      *
      * @return $this
      */
-    public function setFirstName($first_name)
+    public function setFirstName($first_name): static
     {
         if (!is_null($first_name) && (strlen($first_name) > 200)) {
             throw new \InvalidArgumentException('invalid length for $first_name when calling Address., must be smaller than or equal to 200.');
@@ -459,7 +457,7 @@ class Address implements ArrayAccess
      *
      * @return $this
      */
-    public function setLastName($last_name)
+    public function setLastName($last_name): static
     {
         $this->container['last_name'] = $last_name;
 
@@ -470,8 +468,6 @@ class Address implements ArrayAccess
      * Returns true if offset exists. False otherwise.
      *
      * @param int $offset Offset
-     *
-     * @return bool
      */
     public function offsetExists($offset): bool
     {
@@ -482,8 +478,6 @@ class Address implements ArrayAccess
      * Gets offset.
      *
      * @param int $offset Offset
-     *
-     * @return mixed
      */
     public function offsetGet($offset): mixed
     {
@@ -496,7 +490,7 @@ class Address implements ArrayAccess
      * @param int   $offset Offset
      * @param mixed $value  Value to be set
      */
-    public function offsetSet($offset, $value): void
+    public function offsetSet($offset, mixed $value): void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -517,15 +511,13 @@ class Address implements ArrayAccess
 
     /**
      * Gets the string presentation of the object.
-     *
-     * @return string
      */
-    public function __toString()
+    public function __toString(): string
     {
         if (defined('JSON_PRETTY_PRINT')) { // use JSON pretty print
-            return json_encode(\zipMoney\ObjectSerializer::sanitizeForSerialization($this), JSON_PRETTY_PRINT);
+            return (string) json_encode(ObjectSerializer::sanitizeForSerialization($this), JSON_PRETTY_PRINT);
         }
 
-        return json_encode(\zipMoney\ObjectSerializer::sanitizeForSerialization($this));
+        return (string) json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }

--- a/lib/Model/Authority.php
+++ b/lib/Model/Authority.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 /**
@@ -13,8 +14,9 @@ declare(strict_types=1);
 namespace zipMoney\Model;
 
 use ArrayAccess;
+use zipMoney\ObjectSerializer;
 
-class Authority implements ArrayAccess
+class Authority implements ArrayAccess, \Stringable
 {
     public const DISCRIMINATOR = 'subclass';
 
@@ -94,7 +96,7 @@ class Authority implements ArrayAccess
      *
      * @return string[]
      */
-    public function getTypeAllowableValues()
+    public function getTypeAllowableValues(): array
     {
         return [
             self::TYPE_CHECKOUT_ID,
@@ -117,8 +119,8 @@ class Authority implements ArrayAccess
      */
     public function __construct(?array $data = null)
     {
-        $this->container['type'] = isset($data['type']) ? $data['type'] : null;
-        $this->container['value'] = isset($data['value']) ? $data['value'] : null;
+        $this->container['type'] = $data['type'] ?? null;
+        $this->container['value'] = $data['value'] ?? null;
     }
 
     /**
@@ -126,7 +128,7 @@ class Authority implements ArrayAccess
      *
      * @return array invalid properties with reasons
      */
-    public function listInvalidProperties()
+    public function listInvalidProperties(): array
     {
         $invalid_properties = [];
 
@@ -160,11 +162,7 @@ class Authority implements ArrayAccess
         if (!in_array($this->container['type'], $allowed_values)) {
             return false;
         }
-        if ($this->container['value'] === null) {
-            return false;
-        }
-
-        return true;
+        return $this->container['value'] !== null;
     }
 
     /**
@@ -184,7 +182,7 @@ class Authority implements ArrayAccess
      *
      * @return $this
      */
-    public function setType($type)
+    public function setType($type): static
     {
         $allowed_values = ['checkout_id', 'store_code', 'account_token'];
         if ((!in_array($type, $allowed_values))) {
@@ -212,7 +210,7 @@ class Authority implements ArrayAccess
      *
      * @return $this
      */
-    public function setValue($value)
+    public function setValue($value): static
     {
         $this->container['value'] = $value;
 
@@ -223,8 +221,6 @@ class Authority implements ArrayAccess
      * Returns true if offset exists. False otherwise.
      *
      * @param int $offset Offset
-     *
-     * @return bool
      */
     public function offsetExists($offset): bool
     {
@@ -235,8 +231,6 @@ class Authority implements ArrayAccess
      * Gets offset.
      *
      * @param int $offset Offset
-     *
-     * @return mixed
      */
     public function offsetGet($offset): mixed
     {
@@ -249,7 +243,7 @@ class Authority implements ArrayAccess
      * @param int   $offset Offset
      * @param mixed $value  Value to be set
      */
-    public function offsetSet($offset, $value): void
+    public function offsetSet($offset, mixed $value): void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -270,15 +264,13 @@ class Authority implements ArrayAccess
 
     /**
      * Gets the string presentation of the object.
-     *
-     * @return string
      */
-    public function __toString()
+    public function __toString(): string
     {
         if (defined('JSON_PRETTY_PRINT')) { // use JSON pretty print
-            return json_encode(\zipMoney\ObjectSerializer::sanitizeForSerialization($this), JSON_PRETTY_PRINT);
+            return (string) json_encode(ObjectSerializer::sanitizeForSerialization($this), JSON_PRETTY_PRINT);
         }
 
-        return json_encode(\zipMoney\ObjectSerializer::sanitizeForSerialization($this));
+        return (string) json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }

--- a/lib/Model/CaptureChargeRequest.php
+++ b/lib/Model/CaptureChargeRequest.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 /**
@@ -13,8 +14,9 @@ declare(strict_types=1);
 namespace zipMoney\Model;
 
 use ArrayAccess;
+use zipMoney\ObjectSerializer;
 
-class CaptureChargeRequest implements ArrayAccess
+class CaptureChargeRequest implements ArrayAccess, \Stringable
 {
     public const DISCRIMINATOR = 'subclass';
 
@@ -95,7 +97,7 @@ class CaptureChargeRequest implements ArrayAccess
      */
     public function __construct(?array $data = null)
     {
-        $this->container['amount'] = isset($data['amount']) ? $data['amount'] : null;
+        $this->container['amount'] = $data['amount'] ?? null;
     }
 
     /**
@@ -103,7 +105,7 @@ class CaptureChargeRequest implements ArrayAccess
      *
      * @return array invalid properties with reasons
      */
-    public function listInvalidProperties()
+    public function listInvalidProperties(): array
     {
         $invalid_properties = [];
 
@@ -128,11 +130,7 @@ class CaptureChargeRequest implements ArrayAccess
         if ($this->container['amount'] === null) {
             return false;
         }
-        if ($this->container['amount'] < 0) {
-            return false;
-        }
-
-        return true;
+        return $this->container['amount'] >= 0;
     }
 
     /**
@@ -152,7 +150,7 @@ class CaptureChargeRequest implements ArrayAccess
      *
      * @return $this
      */
-    public function setAmount($amount)
+    public function setAmount($amount): static
     {
         if (($amount < 0)) {
             throw new \InvalidArgumentException('invalid value for $amount when calling CaptureChargeRequest., must be bigger than or equal to 0.');
@@ -167,8 +165,6 @@ class CaptureChargeRequest implements ArrayAccess
      * Returns true if offset exists. False otherwise.
      *
      * @param int $offset Offset
-     *
-     * @return bool
      */
     public function offsetExists($offset): bool
     {
@@ -179,8 +175,6 @@ class CaptureChargeRequest implements ArrayAccess
      * Gets offset.
      *
      * @param int $offset Offset
-     *
-     * @return mixed
      */
     public function offsetGet($offset): mixed
     {
@@ -193,7 +187,7 @@ class CaptureChargeRequest implements ArrayAccess
      * @param int   $offset Offset
      * @param mixed $value  Value to be set
      */
-    public function offsetSet($offset, $value): void
+    public function offsetSet($offset, mixed $value): void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -214,15 +208,13 @@ class CaptureChargeRequest implements ArrayAccess
 
     /**
      * Gets the string presentation of the object.
-     *
-     * @return string
      */
-    public function __toString()
+    public function __toString(): string
     {
         if (defined('JSON_PRETTY_PRINT')) { // use JSON pretty print
-            return json_encode(\zipMoney\ObjectSerializer::sanitizeForSerialization($this), JSON_PRETTY_PRINT);
+            return (string) json_encode(ObjectSerializer::sanitizeForSerialization($this), JSON_PRETTY_PRINT);
         }
 
-        return json_encode(\zipMoney\ObjectSerializer::sanitizeForSerialization($this));
+        return (string) json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }

--- a/lib/Model/Charge.php
+++ b/lib/Model/Charge.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 /**
@@ -13,8 +14,9 @@ declare(strict_types=1);
 namespace zipMoney\Model;
 
 use ArrayAccess;
+use zipMoney\ObjectSerializer;
 
-class Charge implements ArrayAccess
+class Charge implements ArrayAccess, \Stringable
 {
     public const DISCRIMINATOR = 'subclass';
 
@@ -137,7 +139,7 @@ class Charge implements ArrayAccess
      *
      * @return string[]
      */
-    public function getStateAllowableValues()
+    public function getStateAllowableValues(): array
     {
         return [
             self::STATE_AUTHORISED,
@@ -163,18 +165,18 @@ class Charge implements ArrayAccess
      */
     public function __construct(?array $data = null)
     {
-        $this->container['id'] = isset($data['id']) ? $data['id'] : null;
-        $this->container['reference'] = isset($data['reference']) ? $data['reference'] : null;
-        $this->container['amount'] = isset($data['amount']) ? $data['amount'] : null;
-        $this->container['currency'] = isset($data['currency']) ? $data['currency'] : null;
-        $this->container['state'] = isset($data['state']) ? $data['state'] : null;
-        $this->container['captured_amount'] = isset($data['captured_amount']) ? $data['captured_amount'] : null;
-        $this->container['refunded_amount'] = isset($data['refunded_amount']) ? $data['refunded_amount'] : null;
-        $this->container['created_date'] = isset($data['created_date']) ? $data['created_date'] : null;
-        $this->container['order'] = isset($data['order']) ? $data['order'] : null;
-        $this->container['metadata'] = isset($data['metadata']) ? $data['metadata'] : null;
-        $this->container['receipt_number'] = isset($data['receipt_number']) ? $data['receipt_number'] : null;
-        $this->container['product'] = isset($data['product']) ? $data['product'] : null;
+        $this->container['id'] = $data['id'] ?? null;
+        $this->container['reference'] = $data['reference'] ?? null;
+        $this->container['amount'] = $data['amount'] ?? null;
+        $this->container['currency'] = $data['currency'] ?? null;
+        $this->container['state'] = $data['state'] ?? null;
+        $this->container['captured_amount'] = $data['captured_amount'] ?? null;
+        $this->container['refunded_amount'] = $data['refunded_amount'] ?? null;
+        $this->container['created_date'] = $data['created_date'] ?? null;
+        $this->container['order'] = $data['order'] ?? null;
+        $this->container['metadata'] = $data['metadata'] ?? null;
+        $this->container['receipt_number'] = $data['receipt_number'] ?? null;
+        $this->container['product'] = $data['product'] ?? null;
     }
 
     /**
@@ -182,7 +184,7 @@ class Charge implements ArrayAccess
      *
      * @return array invalid properties with reasons
      */
-    public function listInvalidProperties()
+    public function listInvalidProperties(): array
     {
         $invalid_properties = [];
 
@@ -269,11 +271,7 @@ class Charge implements ArrayAccess
         if ($this->container['created_date'] === null) {
             return false;
         }
-        if ($this->container['receipt_number'] === null) {
-            return false;
-        }
-
-        return true;
+        return $this->container['receipt_number'] !== null;
     }
 
     /**
@@ -293,7 +291,7 @@ class Charge implements ArrayAccess
      *
      * @return $this
      */
-    public function setId($id)
+    public function setId($id): static
     {
         $this->container['id'] = $id;
 
@@ -317,7 +315,7 @@ class Charge implements ArrayAccess
      *
      * @return $this
      */
-    public function setReference($reference)
+    public function setReference($reference): static
     {
         $this->container['reference'] = $reference;
 
@@ -341,7 +339,7 @@ class Charge implements ArrayAccess
      *
      * @return $this
      */
-    public function setAmount($amount)
+    public function setAmount($amount): static
     {
         $this->container['amount'] = $amount;
 
@@ -365,7 +363,7 @@ class Charge implements ArrayAccess
      *
      * @return $this
      */
-    public function setCurrency($currency)
+    public function setCurrency($currency): static
     {
         $this->container['currency'] = $currency;
 
@@ -389,7 +387,7 @@ class Charge implements ArrayAccess
      *
      * @return $this
      */
-    public function setState($state)
+    public function setState($state): static
     {
         $allowed_values = $this->getStateAllowableValues();
         if ((!in_array($state, $allowed_values))) {
@@ -420,7 +418,7 @@ class Charge implements ArrayAccess
      *
      * @return $this
      */
-    public function setCapturedAmount($captured_amount)
+    public function setCapturedAmount($captured_amount): static
     {
         if (($captured_amount < 0)) {
             throw new \InvalidArgumentException('invalid value for $captured_amount when calling Charge., must be bigger than or equal to 0.');
@@ -448,7 +446,7 @@ class Charge implements ArrayAccess
      *
      * @return $this
      */
-    public function setRefundedAmount($refunded_amount)
+    public function setRefundedAmount($refunded_amount): static
     {
         if (($refunded_amount < 0)) {
             throw new \InvalidArgumentException('invalid value for $refunded_amount when calling Charge., must be bigger than or equal to 0.');
@@ -476,7 +474,7 @@ class Charge implements ArrayAccess
      *
      * @return $this
      */
-    public function setCreatedDate($created_date)
+    public function setCreatedDate($created_date): static
     {
         $this->container['created_date'] = $created_date;
 
@@ -486,7 +484,7 @@ class Charge implements ArrayAccess
     /**
      * Gets order.
      *
-     * @return \zipMoney\Model\ChargeOrder
+     * @return ChargeOrder
      */
     public function getOrder()
     {
@@ -496,11 +494,11 @@ class Charge implements ArrayAccess
     /**
      * Sets order.
      *
-     * @param \zipMoney\Model\ChargeOrder $order
+     * @param ChargeOrder $order
      *
      * @return $this
      */
-    public function setOrder($order)
+    public function setOrder($order): static
     {
         $this->container['order'] = $order;
 
@@ -524,7 +522,7 @@ class Charge implements ArrayAccess
      *
      * @return $this
      */
-    public function setMetadata($metadata)
+    public function setMetadata($metadata): static
     {
         $this->container['metadata'] = $metadata;
 
@@ -548,7 +546,7 @@ class Charge implements ArrayAccess
      *
      * @return $this
      */
-    public function setReceiptNumber($receipt_number)
+    public function setReceiptNumber($receipt_number): static
     {
         $this->container['receipt_number'] = $receipt_number;
 
@@ -562,7 +560,7 @@ class Charge implements ArrayAccess
      *
      * @return $this
      */
-    public function setProduct($product)
+    public function setProduct($product): static
     {
         $this->container['product'] = $product;
 
@@ -583,8 +581,6 @@ class Charge implements ArrayAccess
      * Returns true if offset exists. False otherwise.
      *
      * @param int $offset Offset
-     *
-     * @return bool
      */
     public function offsetExists($offset): bool
     {
@@ -595,8 +591,6 @@ class Charge implements ArrayAccess
      * Gets offset.
      *
      * @param int $offset Offset
-     *
-     * @return mixed
      */
     public function offsetGet($offset): mixed
     {
@@ -609,7 +603,7 @@ class Charge implements ArrayAccess
      * @param int   $offset Offset
      * @param mixed $value  Value to be set
      */
-    public function offsetSet($offset, $value): void
+    public function offsetSet($offset, mixed $value): void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -630,15 +624,13 @@ class Charge implements ArrayAccess
 
     /**
      * Gets the string presentation of the object.
-     *
-     * @return string
      */
-    public function __toString()
+    public function __toString(): string
     {
         if (defined('JSON_PRETTY_PRINT')) { // use JSON pretty print
-            return json_encode(\zipMoney\ObjectSerializer::sanitizeForSerialization($this), JSON_PRETTY_PRINT);
+            return (string) json_encode(ObjectSerializer::sanitizeForSerialization($this), JSON_PRETTY_PRINT);
         }
 
-        return json_encode(\zipMoney\ObjectSerializer::sanitizeForSerialization($this));
+        return (string) json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }

--- a/lib/Model/ChargeCollection.php
+++ b/lib/Model/ChargeCollection.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 /**
@@ -13,8 +14,9 @@ declare(strict_types=1);
 namespace zipMoney\Model;
 
 use ArrayAccess;
+use zipMoney\ObjectSerializer;
 
-class ChargeCollection implements ArrayAccess
+class ChargeCollection implements ArrayAccess, \Stringable
 {
     public const DISCRIMINATOR = 'subclass';
 
@@ -95,7 +97,7 @@ class ChargeCollection implements ArrayAccess
      */
     public function __construct(?array $data = null)
     {
-        $this->container['items'] = isset($data['items']) ? $data['items'] : null;
+        $this->container['items'] = $data['items'] ?? null;
     }
 
     /**
@@ -103,7 +105,7 @@ class ChargeCollection implements ArrayAccess
      *
      * @return array invalid properties with reasons
      */
-    public function listInvalidProperties()
+    public function listInvalidProperties(): array
     {
         $invalid_properties = [];
 
@@ -120,19 +122,15 @@ class ChargeCollection implements ArrayAccess
      *
      * @return bool True if all properties are valid
      */
-    public function valid()
+    public function valid(): bool
     {
-        if ($this->container['items'] === null) {
-            return false;
-        }
-
-        return true;
+        return $this->container['items'] !== null;
     }
 
     /**
      * Gets items.
      *
-     * @return \zipMoney\Model\Charge[]
+     * @return Charge[]
      */
     public function getItems()
     {
@@ -142,11 +140,11 @@ class ChargeCollection implements ArrayAccess
     /**
      * Sets items.
      *
-     * @param \zipMoney\Model\Charge[] $items
+     * @param Charge[] $items
      *
      * @return $this
      */
-    public function setItems($items)
+    public function setItems($items): static
     {
         $this->container['items'] = $items;
 
@@ -157,8 +155,6 @@ class ChargeCollection implements ArrayAccess
      * Returns true if offset exists. False otherwise.
      *
      * @param int $offset Offset
-     *
-     * @return bool
      */
     public function offsetExists($offset): bool
     {
@@ -169,8 +165,6 @@ class ChargeCollection implements ArrayAccess
      * Gets offset.
      *
      * @param int $offset Offset
-     *
-     * @return mixed
      */
     public function offsetGet($offset): mixed
     {
@@ -183,7 +177,7 @@ class ChargeCollection implements ArrayAccess
      * @param int   $offset Offset
      * @param mixed $value  Value to be set
      */
-    public function offsetSet($offset, $value): void
+    public function offsetSet($offset, mixed $value): void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -204,15 +198,13 @@ class ChargeCollection implements ArrayAccess
 
     /**
      * Gets the string presentation of the object.
-     *
-     * @return string
      */
-    public function __toString()
+    public function __toString(): string
     {
         if (defined('JSON_PRETTY_PRINT')) { // use JSON pretty print
-            return json_encode(\zipMoney\ObjectSerializer::sanitizeForSerialization($this), JSON_PRETTY_PRINT);
+            return (string) json_encode(ObjectSerializer::sanitizeForSerialization($this), JSON_PRETTY_PRINT);
         }
 
-        return json_encode(\zipMoney\ObjectSerializer::sanitizeForSerialization($this));
+        return (string) json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }

--- a/lib/Model/ChargeOrder.php
+++ b/lib/Model/ChargeOrder.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 /**
@@ -13,8 +14,9 @@ declare(strict_types=1);
 namespace zipMoney\Model;
 
 use ArrayAccess;
+use zipMoney\ObjectSerializer;
 
-class ChargeOrder implements ArrayAccess
+class ChargeOrder implements ArrayAccess, \Stringable
 {
     public const DISCRIMINATOR = 'subclass';
 
@@ -107,10 +109,10 @@ class ChargeOrder implements ArrayAccess
      */
     public function __construct(?array $data = null)
     {
-        $this->container['reference'] = isset($data['reference']) ? $data['reference'] : null;
-        $this->container['shipping'] = isset($data['shipping']) ? $data['shipping'] : null;
-        $this->container['items'] = isset($data['items']) ? $data['items'] : null;
-        $this->container['cart_reference'] = isset($data['cart_reference']) ? $data['cart_reference'] : null;
+        $this->container['reference'] = $data['reference'] ?? null;
+        $this->container['shipping'] = $data['shipping'] ?? null;
+        $this->container['items'] = $data['items'] ?? null;
+        $this->container['cart_reference'] = $data['cart_reference'] ?? null;
     }
 
     /**
@@ -118,7 +120,7 @@ class ChargeOrder implements ArrayAccess
      *
      * @return array invalid properties with reasons
      */
-    public function listInvalidProperties()
+    public function listInvalidProperties(): array
     {
         $invalid_properties = [];
 
@@ -150,11 +152,7 @@ class ChargeOrder implements ArrayAccess
         if ($this->container['shipping'] === null) {
             return false;
         }
-        if (strlen($this->container['cart_reference']) > 100) {
-            return false;
-        }
-
-        return true;
+        return strlen($this->container['cart_reference']) <= 100;
     }
 
     /**
@@ -174,7 +172,7 @@ class ChargeOrder implements ArrayAccess
      *
      * @return $this
      */
-    public function setReference($reference)
+    public function setReference($reference): static
     {
         if (!is_null($reference) && (strlen($reference) > 50)) {
             throw new \InvalidArgumentException('invalid length for $reference when calling ChargeOrder., must be smaller than or equal to 50.');
@@ -188,7 +186,7 @@ class ChargeOrder implements ArrayAccess
     /**
      * Gets shipping.
      *
-     * @return \zipMoney\Model\OrderShipping
+     * @return OrderShipping
      */
     public function getShipping()
     {
@@ -198,11 +196,11 @@ class ChargeOrder implements ArrayAccess
     /**
      * Sets shipping.
      *
-     * @param \zipMoney\Model\OrderShipping $shipping
+     * @param OrderShipping $shipping
      *
      * @return $this
      */
-    public function setShipping($shipping)
+    public function setShipping($shipping): static
     {
         $this->container['shipping'] = $shipping;
 
@@ -212,7 +210,7 @@ class ChargeOrder implements ArrayAccess
     /**
      * Gets items.
      *
-     * @return \zipMoney\Model\OrderItem[]
+     * @return OrderItem[]
      */
     public function getItems()
     {
@@ -222,11 +220,11 @@ class ChargeOrder implements ArrayAccess
     /**
      * Sets items.
      *
-     * @param \zipMoney\Model\OrderItem[] $items The order item breakdown
+     * @param OrderItem[] $items The order item breakdown
      *
      * @return $this
      */
-    public function setItems($items)
+    public function setItems($items): static
     {
         $this->container['items'] = $items;
 
@@ -250,7 +248,7 @@ class ChargeOrder implements ArrayAccess
      *
      * @return $this
      */
-    public function setCartReference($cart_reference)
+    public function setCartReference($cart_reference): static
     {
         if (!is_null($cart_reference) && (strlen($cart_reference) > 100)) {
             throw new \InvalidArgumentException('invalid length for $cart_reference when calling ChargeOrder., must be smaller than or equal to 100.');
@@ -265,8 +263,6 @@ class ChargeOrder implements ArrayAccess
      * Returns true if offset exists. False otherwise.
      *
      * @param int $offset Offset
-     *
-     * @return bool
      */
     public function offsetExists($offset): bool
     {
@@ -277,8 +273,6 @@ class ChargeOrder implements ArrayAccess
      * Gets offset.
      *
      * @param int $offset Offset
-     *
-     * @return mixed
      */
     public function offsetGet($offset): mixed
     {
@@ -291,7 +285,7 @@ class ChargeOrder implements ArrayAccess
      * @param int   $offset Offset
      * @param mixed $value  Value to be set
      */
-    public function offsetSet($offset, $value): void
+    public function offsetSet($offset, mixed $value): void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -312,15 +306,13 @@ class ChargeOrder implements ArrayAccess
 
     /**
      * Gets the string presentation of the object.
-     *
-     * @return string
      */
-    public function __toString()
+    public function __toString(): string
     {
         if (defined('JSON_PRETTY_PRINT')) { // use JSON pretty print
-            return json_encode(\zipMoney\ObjectSerializer::sanitizeForSerialization($this), JSON_PRETTY_PRINT);
+            return (string) json_encode(ObjectSerializer::sanitizeForSerialization($this), JSON_PRETTY_PRINT);
         }
 
-        return json_encode(\zipMoney\ObjectSerializer::sanitizeForSerialization($this));
+        return (string) json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }

--- a/lib/Model/Checkout.php
+++ b/lib/Model/Checkout.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 /**
@@ -13,8 +14,9 @@ declare(strict_types=1);
 namespace zipMoney\Model;
 
 use ArrayAccess;
+use zipMoney\ObjectSerializer;
 
-class Checkout implements ArrayAccess
+class Checkout implements ArrayAccess, \Stringable
 {
     public const DISCRIMINATOR = 'subclass';
 
@@ -135,7 +137,7 @@ class Checkout implements ArrayAccess
      *
      * @return string[]
      */
-    public function getTypeAllowableValues()
+    public function getTypeAllowableValues(): array
     {
         return [
             self::TYPE_STANDARD,
@@ -148,7 +150,7 @@ class Checkout implements ArrayAccess
      *
      * @return string[]
      */
-    public function getStateAllowableValues()
+    public function getStateAllowableValues(): array
     {
         return [
             self::STATE_CREATED,
@@ -174,17 +176,17 @@ class Checkout implements ArrayAccess
      */
     public function __construct(?array $data = null)
     {
-        $this->container['id'] = isset($data['id']) ? $data['id'] : null;
-        $this->container['uri'] = isset($data['uri']) ? $data['uri'] : null;
-        $this->container['type'] = isset($data['type']) ? $data['type'] : 'standard';
-        $this->container['shopper'] = isset($data['shopper']) ? $data['shopper'] : null;
-        $this->container['order'] = isset($data['order']) ? $data['order'] : null;
-        $this->container['features'] = isset($data['features']) ? $data['features'] : null;
-        $this->container['config'] = isset($data['config']) ? $data['config'] : null;
-        $this->container['created'] = isset($data['created']) ? $data['created'] : null;
-        $this->container['state'] = isset($data['state']) ? $data['state'] : null;
-        $this->container['customer_id'] = isset($data['customer_id']) ? $data['customer_id'] : null;
-        $this->container['metadata'] = isset($data['metadata']) ? $data['metadata'] : null;
+        $this->container['id'] = $data['id'] ?? null;
+        $this->container['uri'] = $data['uri'] ?? null;
+        $this->container['type'] = $data['type'] ?? 'standard';
+        $this->container['shopper'] = $data['shopper'] ?? null;
+        $this->container['order'] = $data['order'] ?? null;
+        $this->container['features'] = $data['features'] ?? null;
+        $this->container['config'] = $data['config'] ?? null;
+        $this->container['created'] = $data['created'] ?? null;
+        $this->container['state'] = $data['state'] ?? null;
+        $this->container['customer_id'] = $data['customer_id'] ?? null;
+        $this->container['metadata'] = $data['metadata'] ?? null;
     }
 
     /**
@@ -192,7 +194,7 @@ class Checkout implements ArrayAccess
      *
      * @return array invalid properties with reasons
      */
-    public function listInvalidProperties()
+    public function listInvalidProperties(): array
     {
         $invalid_properties = [];
 
@@ -246,11 +248,7 @@ class Checkout implements ArrayAccess
             return false;
         }
         $allowed_values = ['created', 'expired', 'approved', 'completed', 'cancelled', 'declined'];
-        if (!in_array($this->container['state'], $allowed_values)) {
-            return false;
-        }
-
-        return true;
+        return in_array($this->container['state'], $allowed_values);
     }
 
     /**
@@ -270,7 +268,7 @@ class Checkout implements ArrayAccess
      *
      * @return $this
      */
-    public function setId($id)
+    public function setId($id): static
     {
         $this->container['id'] = $id;
 
@@ -294,7 +292,7 @@ class Checkout implements ArrayAccess
      *
      * @return $this
      */
-    public function setUri($uri)
+    public function setUri($uri): static
     {
         $this->container['uri'] = $uri;
 
@@ -318,7 +316,7 @@ class Checkout implements ArrayAccess
      *
      * @return $this
      */
-    public function setType($type)
+    public function setType($type): static
     {
         $allowed_values = ['standard', 'express'];
         if (!is_null($type) && (!in_array($type, $allowed_values))) {
@@ -332,7 +330,7 @@ class Checkout implements ArrayAccess
     /**
      * Gets shopper.
      *
-     * @return \zipMoney\Model\Shopper
+     * @return Shopper
      */
     public function getShopper()
     {
@@ -342,11 +340,11 @@ class Checkout implements ArrayAccess
     /**
      * Sets shopper.
      *
-     * @param \zipMoney\Model\Shopper $shopper
+     * @param Shopper $shopper
      *
      * @return $this
      */
-    public function setShopper($shopper)
+    public function setShopper($shopper): static
     {
         $this->container['shopper'] = $shopper;
 
@@ -356,7 +354,7 @@ class Checkout implements ArrayAccess
     /**
      * Gets order.
      *
-     * @return \zipMoney\Model\CheckoutOrder
+     * @return CheckoutOrder
      */
     public function getOrder()
     {
@@ -366,11 +364,11 @@ class Checkout implements ArrayAccess
     /**
      * Sets order.
      *
-     * @param \zipMoney\Model\CheckoutOrder $order
+     * @param CheckoutOrder $order
      *
      * @return $this
      */
-    public function setOrder($order)
+    public function setOrder($order): static
     {
         $this->container['order'] = $order;
 
@@ -380,7 +378,7 @@ class Checkout implements ArrayAccess
     /**
      * Gets features.
      *
-     * @return \zipMoney\Model\CheckoutFeatures
+     * @return CheckoutFeatures
      */
     public function getFeatures()
     {
@@ -390,11 +388,11 @@ class Checkout implements ArrayAccess
     /**
      * Sets features.
      *
-     * @param \zipMoney\Model\CheckoutFeatures $features
+     * @param CheckoutFeatures $features
      *
      * @return $this
      */
-    public function setFeatures($features)
+    public function setFeatures($features): static
     {
         $this->container['features'] = $features;
 
@@ -404,7 +402,7 @@ class Checkout implements ArrayAccess
     /**
      * Gets config.
      *
-     * @return \zipMoney\Model\CheckoutConfiguration
+     * @return CheckoutConfiguration
      */
     public function getConfig()
     {
@@ -414,11 +412,11 @@ class Checkout implements ArrayAccess
     /**
      * Sets config.
      *
-     * @param \zipMoney\Model\CheckoutConfiguration $config
+     * @param CheckoutConfiguration $config
      *
      * @return $this
      */
-    public function setConfig($config)
+    public function setConfig($config): static
     {
         $this->container['config'] = $config;
 
@@ -442,7 +440,7 @@ class Checkout implements ArrayAccess
      *
      * @return $this
      */
-    public function setCreated($created)
+    public function setCreated($created): static
     {
         $this->container['created'] = $created;
 
@@ -466,7 +464,7 @@ class Checkout implements ArrayAccess
      *
      * @return $this
      */
-    public function setState($state)
+    public function setState($state): static
     {
         $allowed_values = ['created', 'expired', 'approved', 'completed', 'cancelled', 'declined'];
         if ((!in_array($state, $allowed_values))) {
@@ -494,7 +492,7 @@ class Checkout implements ArrayAccess
      *
      * @return $this
      */
-    public function setCustomerId($customer_id)
+    public function setCustomerId($customer_id): static
     {
         $this->container['customer_id'] = $customer_id;
 
@@ -504,7 +502,7 @@ class Checkout implements ArrayAccess
     /**
      * Gets metadata.
      *
-     * @return \zipMoney\Model\Metadata
+     * @return Metadata
      */
     public function getMetadata()
     {
@@ -514,11 +512,11 @@ class Checkout implements ArrayAccess
     /**
      * Sets metadata.
      *
-     * @param \zipMoney\Model\Metadata $metadata
+     * @param Metadata $metadata
      *
      * @return $this
      */
-    public function setMetadata($metadata)
+    public function setMetadata($metadata): static
     {
         $this->container['metadata'] = $metadata;
 
@@ -529,8 +527,6 @@ class Checkout implements ArrayAccess
      * Returns true if offset exists. False otherwise.
      *
      * @param int $offset Offset
-     *
-     * @return bool
      */
     public function offsetExists($offset): bool
     {
@@ -541,8 +537,6 @@ class Checkout implements ArrayAccess
      * Gets offset.
      *
      * @param int $offset Offset
-     *
-     * @return mixed
      */
     public function offsetGet($offset): mixed
     {
@@ -555,7 +549,7 @@ class Checkout implements ArrayAccess
      * @param int   $offset Offset
      * @param mixed $value  Value to be set
      */
-    public function offsetSet($offset, $value): void
+    public function offsetSet($offset, mixed $value): void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -576,15 +570,13 @@ class Checkout implements ArrayAccess
 
     /**
      * Gets the string presentation of the object.
-     *
-     * @return string
      */
-    public function __toString()
+    public function __toString(): string
     {
         if (defined('JSON_PRETTY_PRINT')) { // use JSON pretty print
-            return json_encode(\zipMoney\ObjectSerializer::sanitizeForSerialization($this), JSON_PRETTY_PRINT);
+            return (string) json_encode(ObjectSerializer::sanitizeForSerialization($this), JSON_PRETTY_PRINT);
         }
 
-        return json_encode(\zipMoney\ObjectSerializer::sanitizeForSerialization($this));
+        return (string) json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }

--- a/lib/Model/CheckoutConfiguration.php
+++ b/lib/Model/CheckoutConfiguration.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 /**
@@ -13,8 +14,9 @@ declare(strict_types=1);
 namespace zipMoney\Model;
 
 use ArrayAccess;
+use zipMoney\ObjectSerializer;
 
-class CheckoutConfiguration implements ArrayAccess
+class CheckoutConfiguration implements ArrayAccess, \Stringable
 {
     public const DISCRIMINATOR = 'subclass';
 
@@ -95,7 +97,7 @@ class CheckoutConfiguration implements ArrayAccess
      */
     public function __construct(?array $data = null)
     {
-        $this->container['redirect_uri'] = isset($data['redirect_uri']) ? $data['redirect_uri'] : null;
+        $this->container['redirect_uri'] = $data['redirect_uri'] ?? null;
     }
 
     /**
@@ -103,7 +105,7 @@ class CheckoutConfiguration implements ArrayAccess
      *
      * @return array invalid properties with reasons
      */
-    public function listInvalidProperties()
+    public function listInvalidProperties(): array
     {
         $invalid_properties = [];
 
@@ -120,13 +122,9 @@ class CheckoutConfiguration implements ArrayAccess
      *
      * @return bool True if all properties are valid
      */
-    public function valid()
+    public function valid(): bool
     {
-        if ($this->container['redirect_uri'] === null) {
-            return false;
-        }
-
-        return true;
+        return $this->container['redirect_uri'] !== null;
     }
 
     /**
@@ -146,7 +144,7 @@ class CheckoutConfiguration implements ArrayAccess
      *
      * @return $this
      */
-    public function setRedirectUri($redirect_uri)
+    public function setRedirectUri($redirect_uri): static
     {
         $this->container['redirect_uri'] = $redirect_uri;
 
@@ -157,8 +155,6 @@ class CheckoutConfiguration implements ArrayAccess
      * Returns true if offset exists. False otherwise.
      *
      * @param int $offset Offset
-     *
-     * @return bool
      */
     public function offsetExists($offset): bool
     {
@@ -169,8 +165,6 @@ class CheckoutConfiguration implements ArrayAccess
      * Gets offset.
      *
      * @param int $offset Offset
-     *
-     * @return mixed
      */
     public function offsetGet($offset): mixed
     {
@@ -183,7 +177,7 @@ class CheckoutConfiguration implements ArrayAccess
      * @param int   $offset Offset
      * @param mixed $value  Value to be set
      */
-    public function offsetSet($offset, $value): void
+    public function offsetSet($offset, mixed $value): void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -204,15 +198,13 @@ class CheckoutConfiguration implements ArrayAccess
 
     /**
      * Gets the string presentation of the object.
-     *
-     * @return string
      */
-    public function __toString()
+    public function __toString(): string
     {
         if (defined('JSON_PRETTY_PRINT')) { // use JSON pretty print
-            return json_encode(\zipMoney\ObjectSerializer::sanitizeForSerialization($this), JSON_PRETTY_PRINT);
+            return (string) json_encode(ObjectSerializer::sanitizeForSerialization($this), JSON_PRETTY_PRINT);
         }
 
-        return json_encode(\zipMoney\ObjectSerializer::sanitizeForSerialization($this));
+        return (string) json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }

--- a/lib/Model/CheckoutFeatures.php
+++ b/lib/Model/CheckoutFeatures.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 /**
@@ -13,8 +14,9 @@ declare(strict_types=1);
 namespace zipMoney\Model;
 
 use ArrayAccess;
+use zipMoney\ObjectSerializer;
 
-class CheckoutFeatures implements ArrayAccess
+class CheckoutFeatures implements ArrayAccess, \Stringable
 {
     public const DISCRIMINATOR = 'subclass';
 
@@ -95,7 +97,7 @@ class CheckoutFeatures implements ArrayAccess
      */
     public function __construct(?array $data = null)
     {
-        $this->container['tokenisation'] = isset($data['tokenisation']) ? $data['tokenisation'] : null;
+        $this->container['tokenisation'] = $data['tokenisation'] ?? null;
     }
 
     /**
@@ -103,7 +105,7 @@ class CheckoutFeatures implements ArrayAccess
      *
      * @return array invalid properties with reasons
      */
-    public function listInvalidProperties()
+    public function listInvalidProperties(): array
     {
         return [];
     }
@@ -114,7 +116,7 @@ class CheckoutFeatures implements ArrayAccess
      *
      * @return bool True if all properties are valid
      */
-    public function valid()
+    public function valid(): bool
     {
         return true;
     }
@@ -122,7 +124,7 @@ class CheckoutFeatures implements ArrayAccess
     /**
      * Gets tokenisation.
      *
-     * @return \zipMoney\Model\CheckoutFeaturesTokenisation
+     * @return CheckoutFeaturesTokenisation
      */
     public function getTokenisation()
     {
@@ -132,11 +134,11 @@ class CheckoutFeatures implements ArrayAccess
     /**
      * Sets tokenisation.
      *
-     * @param \zipMoney\Model\CheckoutFeaturesTokenisation $tokenisation
+     * @param CheckoutFeaturesTokenisation $tokenisation
      *
      * @return $this
      */
-    public function setTokenisation($tokenisation)
+    public function setTokenisation($tokenisation): static
     {
         $this->container['tokenisation'] = $tokenisation;
 
@@ -147,8 +149,6 @@ class CheckoutFeatures implements ArrayAccess
      * Returns true if offset exists. False otherwise.
      *
      * @param int $offset Offset
-     *
-     * @return bool
      */
     public function offsetExists($offset): bool
     {
@@ -159,8 +159,6 @@ class CheckoutFeatures implements ArrayAccess
      * Gets offset.
      *
      * @param int $offset Offset
-     *
-     * @return mixed
      */
     public function offsetGet($offset): mixed
     {
@@ -173,7 +171,7 @@ class CheckoutFeatures implements ArrayAccess
      * @param int   $offset Offset
      * @param mixed $value  Value to be set
      */
-    public function offsetSet($offset, $value): void
+    public function offsetSet($offset, mixed $value): void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -194,15 +192,13 @@ class CheckoutFeatures implements ArrayAccess
 
     /**
      * Gets the string presentation of the object.
-     *
-     * @return string
      */
-    public function __toString()
+    public function __toString(): string
     {
         if (defined('JSON_PRETTY_PRINT')) { // use JSON pretty print
-            return json_encode(\zipMoney\ObjectSerializer::sanitizeForSerialization($this), JSON_PRETTY_PRINT);
+            return (string) json_encode(ObjectSerializer::sanitizeForSerialization($this), JSON_PRETTY_PRINT);
         }
 
-        return json_encode(\zipMoney\ObjectSerializer::sanitizeForSerialization($this));
+        return (string) json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }

--- a/lib/Model/CheckoutFeaturesTokenisation.php
+++ b/lib/Model/CheckoutFeaturesTokenisation.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 /**
@@ -13,8 +14,9 @@ declare(strict_types=1);
 namespace zipMoney\Model;
 
 use ArrayAccess;
+use zipMoney\ObjectSerializer;
 
-class CheckoutFeaturesTokenisation implements ArrayAccess
+class CheckoutFeaturesTokenisation implements ArrayAccess, \Stringable
 {
     public const DISCRIMINATOR = 'subclass';
 
@@ -95,7 +97,7 @@ class CheckoutFeaturesTokenisation implements ArrayAccess
      */
     public function __construct(?array $data = null)
     {
-        $this->container['required'] = isset($data['required']) ? $data['required'] : true;
+        $this->container['required'] = $data['required'] ?? true;
     }
 
     /**
@@ -103,7 +105,7 @@ class CheckoutFeaturesTokenisation implements ArrayAccess
      *
      * @return array invalid properties with reasons
      */
-    public function listInvalidProperties()
+    public function listInvalidProperties(): array
     {
         return [];
     }
@@ -114,7 +116,7 @@ class CheckoutFeaturesTokenisation implements ArrayAccess
      *
      * @return bool True if all properties are valid
      */
-    public function valid()
+    public function valid(): bool
     {
         return true;
     }
@@ -136,7 +138,7 @@ class CheckoutFeaturesTokenisation implements ArrayAccess
      *
      * @return $this
      */
-    public function setRequired($required)
+    public function setRequired($required): static
     {
         $this->container['required'] = $required;
 
@@ -147,8 +149,6 @@ class CheckoutFeaturesTokenisation implements ArrayAccess
      * Returns true if offset exists. False otherwise.
      *
      * @param int $offset Offset
-     *
-     * @return bool
      */
     public function offsetExists($offset): bool
     {
@@ -159,8 +159,6 @@ class CheckoutFeaturesTokenisation implements ArrayAccess
      * Gets offset.
      *
      * @param int $offset Offset
-     *
-     * @return mixed
      */
     public function offsetGet($offset): mixed
     {
@@ -173,7 +171,7 @@ class CheckoutFeaturesTokenisation implements ArrayAccess
      * @param int   $offset Offset
      * @param mixed $value  Value to be set
      */
-    public function offsetSet($offset, $value): void
+    public function offsetSet($offset, mixed $value): void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -194,15 +192,13 @@ class CheckoutFeaturesTokenisation implements ArrayAccess
 
     /**
      * Gets the string presentation of the object.
-     *
-     * @return string
      */
-    public function __toString()
+    public function __toString(): string
     {
         if (defined('JSON_PRETTY_PRINT')) { // use JSON pretty print
-            return json_encode(\zipMoney\ObjectSerializer::sanitizeForSerialization($this), JSON_PRETTY_PRINT);
+            return (string) json_encode(ObjectSerializer::sanitizeForSerialization($this), JSON_PRETTY_PRINT);
         }
 
-        return json_encode(\zipMoney\ObjectSerializer::sanitizeForSerialization($this));
+        return (string) json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }

--- a/lib/Model/CheckoutOrder.php
+++ b/lib/Model/CheckoutOrder.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 /**
@@ -13,8 +14,9 @@ declare(strict_types=1);
 namespace zipMoney\Model;
 
 use ArrayAccess;
+use zipMoney\ObjectSerializer;
 
-class CheckoutOrder implements ArrayAccess
+class CheckoutOrder implements ArrayAccess, \Stringable
 {
     public const DISCRIMINATOR = 'subclass';
 
@@ -115,12 +117,12 @@ class CheckoutOrder implements ArrayAccess
      */
     public function __construct(?array $data = null)
     {
-        $this->container['reference'] = isset($data['reference']) ? $data['reference'] : null;
-        $this->container['amount'] = isset($data['amount']) ? $data['amount'] : null;
-        $this->container['currency'] = isset($data['currency']) ? $data['currency'] : null;
-        $this->container['shipping'] = isset($data['shipping']) ? $data['shipping'] : null;
-        $this->container['items'] = isset($data['items']) ? $data['items'] : null;
-        $this->container['cart_reference'] = isset($data['cart_reference']) ? $data['cart_reference'] : null;
+        $this->container['reference'] = $data['reference'] ?? null;
+        $this->container['amount'] = $data['amount'] ?? null;
+        $this->container['currency'] = $data['currency'] ?? null;
+        $this->container['shipping'] = $data['shipping'] ?? null;
+        $this->container['items'] = $data['items'] ?? null;
+        $this->container['cart_reference'] = $data['cart_reference'] ?? null;
     }
 
     /**
@@ -128,7 +130,7 @@ class CheckoutOrder implements ArrayAccess
      *
      * @return array invalid properties with reasons
      */
-    public function listInvalidProperties()
+    public function listInvalidProperties(): array
     {
         $invalid_properties = [];
 
@@ -179,11 +181,7 @@ class CheckoutOrder implements ArrayAccess
         if ($this->container['shipping'] === null) {
             return false;
         }
-        if (strlen($this->container['cart_reference']) > 200) {
-            return false;
-        }
-
-        return true;
+        return strlen($this->container['cart_reference']) <= 200;
     }
 
     /**
@@ -203,7 +201,7 @@ class CheckoutOrder implements ArrayAccess
      *
      * @return $this
      */
-    public function setReference($reference)
+    public function setReference($reference): static
     {
         if (!is_null($reference) && (strlen($reference) > 200)) {
             throw new \InvalidArgumentException('invalid length for $reference when calling CheckoutOrder., must be smaller than or equal to 200.');
@@ -231,7 +229,7 @@ class CheckoutOrder implements ArrayAccess
      *
      * @return $this
      */
-    public function setAmount($amount)
+    public function setAmount($amount): static
     {
         if (($amount < 0)) {
             throw new \InvalidArgumentException('invalid value for $amount when calling CheckoutOrder., must be bigger than or equal to 0.');
@@ -259,7 +257,7 @@ class CheckoutOrder implements ArrayAccess
      *
      * @return $this
      */
-    public function setCurrency($currency)
+    public function setCurrency($currency): static
     {
         $this->container['currency'] = $currency;
 
@@ -269,7 +267,7 @@ class CheckoutOrder implements ArrayAccess
     /**
      * Gets shipping.
      *
-     * @return \zipMoney\Model\OrderShipping
+     * @return OrderShipping
      */
     public function getShipping()
     {
@@ -279,11 +277,11 @@ class CheckoutOrder implements ArrayAccess
     /**
      * Sets shipping.
      *
-     * @param \zipMoney\Model\OrderShipping $shipping
+     * @param OrderShipping $shipping
      *
      * @return $this
      */
-    public function setShipping($shipping)
+    public function setShipping($shipping): static
     {
         $this->container['shipping'] = $shipping;
 
@@ -293,7 +291,7 @@ class CheckoutOrder implements ArrayAccess
     /**
      * Gets items.
      *
-     * @return \zipMoney\Model\OrderItem[]
+     * @return OrderItem[]
      */
     public function getItems()
     {
@@ -303,11 +301,11 @@ class CheckoutOrder implements ArrayAccess
     /**
      * Sets items.
      *
-     * @param \zipMoney\Model\OrderItem[] $items The order item breakdown
+     * @param OrderItem[] $items The order item breakdown
      *
      * @return $this
      */
-    public function setItems($items)
+    public function setItems($items): static
     {
         $this->container['items'] = $items;
 
@@ -331,7 +329,7 @@ class CheckoutOrder implements ArrayAccess
      *
      * @return $this
      */
-    public function setCartReference($cart_reference)
+    public function setCartReference($cart_reference): static
     {
         if (!is_null($cart_reference) && (strlen($cart_reference) > 200)) {
             throw new \InvalidArgumentException('invalid length for $cart_reference when calling CheckoutOrder., must be smaller than or equal to 200.');
@@ -346,8 +344,6 @@ class CheckoutOrder implements ArrayAccess
      * Returns true if offset exists. False otherwise.
      *
      * @param int $offset Offset
-     *
-     * @return bool
      */
     public function offsetExists($offset): bool
     {
@@ -358,8 +354,6 @@ class CheckoutOrder implements ArrayAccess
      * Gets offset.
      *
      * @param int $offset Offset
-     *
-     * @return mixed
      */
     public function offsetGet($offset): mixed
     {
@@ -372,7 +366,7 @@ class CheckoutOrder implements ArrayAccess
      * @param int   $offset Offset
      * @param mixed $value  Value to be set
      */
-    public function offsetSet($offset, $value): void
+    public function offsetSet($offset, mixed $value): void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -393,15 +387,13 @@ class CheckoutOrder implements ArrayAccess
 
     /**
      * Gets the string presentation of the object.
-     *
-     * @return string
      */
-    public function __toString()
+    public function __toString(): string
     {
         if (defined('JSON_PRETTY_PRINT')) { // use JSON pretty print
-            return json_encode(\zipMoney\ObjectSerializer::sanitizeForSerialization($this), JSON_PRETTY_PRINT);
+            return (string) json_encode(ObjectSerializer::sanitizeForSerialization($this), JSON_PRETTY_PRINT);
         }
 
-        return json_encode(\zipMoney\ObjectSerializer::sanitizeForSerialization($this));
+        return (string) json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }

--- a/lib/Model/CreateChargeRequest.php
+++ b/lib/Model/CreateChargeRequest.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 /**
@@ -13,8 +14,9 @@ declare(strict_types=1);
 namespace zipMoney\Model;
 
 use ArrayAccess;
+use zipMoney\ObjectSerializer;
 
-class CreateChargeRequest implements ArrayAccess
+class CreateChargeRequest implements ArrayAccess, \Stringable
 {
     public const DISCRIMINATOR = 'subclass';
 
@@ -119,13 +121,13 @@ class CreateChargeRequest implements ArrayAccess
      */
     public function __construct(?array $data = null)
     {
-        $this->container['authority'] = isset($data['authority']) ? $data['authority'] : null;
-        $this->container['reference'] = isset($data['reference']) ? $data['reference'] : null;
-        $this->container['amount'] = isset($data['amount']) ? $data['amount'] : null;
-        $this->container['currency'] = isset($data['currency']) ? $data['currency'] : null;
-        $this->container['capture'] = isset($data['capture']) ? $data['capture'] : true;
-        $this->container['order'] = isset($data['order']) ? $data['order'] : null;
-        $this->container['metadata'] = isset($data['metadata']) ? $data['metadata'] : null;
+        $this->container['authority'] = $data['authority'] ?? null;
+        $this->container['reference'] = $data['reference'] ?? null;
+        $this->container['amount'] = $data['amount'] ?? null;
+        $this->container['currency'] = $data['currency'] ?? null;
+        $this->container['capture'] = $data['capture'] ?? true;
+        $this->container['order'] = $data['order'] ?? null;
+        $this->container['metadata'] = $data['metadata'] ?? null;
     }
 
     /**
@@ -133,7 +135,7 @@ class CreateChargeRequest implements ArrayAccess
      *
      * @return array invalid properties with reasons
      */
-    public function listInvalidProperties()
+    public function listInvalidProperties(): array
     {
         $invalid_properties = [];
 
@@ -164,17 +166,13 @@ class CreateChargeRequest implements ArrayAccess
         if ($this->container['amount'] === null) {
             return false;
         }
-        if ($this->container['currency'] === null) {
-            return false;
-        }
-
-        return true;
+        return $this->container['currency'] !== null;
     }
 
     /**
      * Gets authority.
      *
-     * @return \zipMoney\Model\Authority
+     * @return Authority
      */
     public function getAuthority()
     {
@@ -184,11 +182,11 @@ class CreateChargeRequest implements ArrayAccess
     /**
      * Sets authority.
      *
-     * @param \zipMoney\Model\Authority $authority
+     * @param Authority $authority
      *
      * @return $this
      */
-    public function setAuthority($authority)
+    public function setAuthority($authority): static
     {
         $this->container['authority'] = $authority;
 
@@ -212,7 +210,7 @@ class CreateChargeRequest implements ArrayAccess
      *
      * @return $this
      */
-    public function setReference($reference)
+    public function setReference($reference): static
     {
         $this->container['reference'] = $reference;
 
@@ -236,7 +234,7 @@ class CreateChargeRequest implements ArrayAccess
      *
      * @return $this
      */
-    public function setAmount($amount)
+    public function setAmount($amount): static
     {
         $this->container['amount'] = $amount;
 
@@ -260,7 +258,7 @@ class CreateChargeRequest implements ArrayAccess
      *
      * @return $this
      */
-    public function setCurrency($currency)
+    public function setCurrency($currency): static
     {
         $this->container['currency'] = $currency;
 
@@ -284,7 +282,7 @@ class CreateChargeRequest implements ArrayAccess
      *
      * @return $this
      */
-    public function setCapture($capture)
+    public function setCapture($capture): static
     {
         $this->container['capture'] = $capture;
 
@@ -294,7 +292,7 @@ class CreateChargeRequest implements ArrayAccess
     /**
      * Gets order.
      *
-     * @return \zipMoney\Model\ChargeOrder
+     * @return ChargeOrder
      */
     public function getOrder()
     {
@@ -304,11 +302,11 @@ class CreateChargeRequest implements ArrayAccess
     /**
      * Sets order.
      *
-     * @param \zipMoney\Model\ChargeOrder $order
+     * @param ChargeOrder $order
      *
      * @return $this
      */
-    public function setOrder($order)
+    public function setOrder($order): static
     {
         $this->container['order'] = $order;
 
@@ -332,7 +330,7 @@ class CreateChargeRequest implements ArrayAccess
      *
      * @return $this
      */
-    public function setMetadata($metadata)
+    public function setMetadata($metadata): static
     {
         $this->container['metadata'] = $metadata;
 
@@ -343,8 +341,6 @@ class CreateChargeRequest implements ArrayAccess
      * Returns true if offset exists. False otherwise.
      *
      * @param int $offset Offset
-     *
-     * @return bool
      */
     public function offsetExists($offset): bool
     {
@@ -355,8 +351,6 @@ class CreateChargeRequest implements ArrayAccess
      * Gets offset.
      *
      * @param int $offset Offset
-     *
-     * @return mixed
      */
     public function offsetGet($offset): mixed
     {
@@ -369,7 +363,7 @@ class CreateChargeRequest implements ArrayAccess
      * @param int   $offset Offset
      * @param mixed $value  Value to be set
      */
-    public function offsetSet($offset, $value): void
+    public function offsetSet($offset, mixed $value): void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -390,15 +384,13 @@ class CreateChargeRequest implements ArrayAccess
 
     /**
      * Gets the string presentation of the object.
-     *
-     * @return string
      */
-    public function __toString()
+    public function __toString(): string
     {
         if (defined('JSON_PRETTY_PRINT')) { // use JSON pretty print
-            return json_encode(\zipMoney\ObjectSerializer::sanitizeForSerialization($this), JSON_PRETTY_PRINT);
+            return (string) json_encode(ObjectSerializer::sanitizeForSerialization($this), JSON_PRETTY_PRINT);
         }
 
-        return json_encode(\zipMoney\ObjectSerializer::sanitizeForSerialization($this));
+        return (string) json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }

--- a/lib/Model/CreateCheckoutRequest.php
+++ b/lib/Model/CreateCheckoutRequest.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 /**
@@ -13,8 +14,9 @@ declare(strict_types=1);
 namespace zipMoney\Model;
 
 use ArrayAccess;
+use zipMoney\ObjectSerializer;
 
-class CreateCheckoutRequest implements ArrayAccess
+class CreateCheckoutRequest implements ArrayAccess, \Stringable
 {
     public const DISCRIMINATOR = 'subclass';
 
@@ -109,7 +111,7 @@ class CreateCheckoutRequest implements ArrayAccess
      *
      * @return string[]
      */
-    public function getTypeAllowableValues()
+    public function getTypeAllowableValues(): array
     {
         return [
             self::TYPE_STANDARD,
@@ -131,12 +133,12 @@ class CreateCheckoutRequest implements ArrayAccess
      */
     public function __construct(?array $data = null)
     {
-        $this->container['type'] = isset($data['type']) ? $data['type'] : 'standard';
-        $this->container['shopper'] = isset($data['shopper']) ? $data['shopper'] : null;
-        $this->container['order'] = isset($data['order']) ? $data['order'] : null;
-        $this->container['features'] = isset($data['features']) ? $data['features'] : null;
-        $this->container['metadata'] = isset($data['metadata']) ? $data['metadata'] : null;
-        $this->container['config'] = isset($data['config']) ? $data['config'] : null;
+        $this->container['type'] = $data['type'] ?? 'standard';
+        $this->container['shopper'] = $data['shopper'] ?? null;
+        $this->container['order'] = $data['order'] ?? null;
+        $this->container['features'] = $data['features'] ?? null;
+        $this->container['metadata'] = $data['metadata'] ?? null;
+        $this->container['config'] = $data['config'] ?? null;
     }
 
     /**
@@ -144,7 +146,7 @@ class CreateCheckoutRequest implements ArrayAccess
      *
      * @return array invalid properties with reasons
      */
-    public function listInvalidProperties()
+    public function listInvalidProperties(): array
     {
         $invalid_properties = [];
 
@@ -178,11 +180,7 @@ class CreateCheckoutRequest implements ArrayAccess
         if ($this->container['order'] === null) {
             return false;
         }
-        if ($this->container['config'] === null) {
-            return false;
-        }
-
-        return true;
+        return $this->container['config'] !== null;
     }
 
     /**
@@ -202,7 +200,7 @@ class CreateCheckoutRequest implements ArrayAccess
      *
      * @return $this
      */
-    public function setType($type)
+    public function setType($type): static
     {
         $allowed_values = ['standard', 'express'];
         if (!is_null($type) && (!in_array($type, $allowed_values))) {
@@ -216,7 +214,7 @@ class CreateCheckoutRequest implements ArrayAccess
     /**
      * Gets shopper.
      *
-     * @return \zipMoney\Model\Shopper
+     * @return Shopper
      */
     public function getShopper()
     {
@@ -226,11 +224,11 @@ class CreateCheckoutRequest implements ArrayAccess
     /**
      * Sets shopper.
      *
-     * @param \zipMoney\Model\Shopper $shopper
+     * @param Shopper $shopper
      *
      * @return $this
      */
-    public function setShopper($shopper)
+    public function setShopper($shopper): static
     {
         $this->container['shopper'] = $shopper;
 
@@ -240,7 +238,7 @@ class CreateCheckoutRequest implements ArrayAccess
     /**
      * Gets order.
      *
-     * @return \zipMoney\Model\CheckoutOrder
+     * @return CheckoutOrder
      */
     public function getOrder()
     {
@@ -250,11 +248,11 @@ class CreateCheckoutRequest implements ArrayAccess
     /**
      * Sets order.
      *
-     * @param \zipMoney\Model\CheckoutOrder $order
+     * @param CheckoutOrder $order
      *
      * @return $this
      */
-    public function setOrder($order)
+    public function setOrder($order): static
     {
         $this->container['order'] = $order;
 
@@ -264,7 +262,7 @@ class CreateCheckoutRequest implements ArrayAccess
     /**
      * Gets features.
      *
-     * @return \zipMoney\Model\CreateCheckoutRequestFeatures
+     * @return CreateCheckoutRequestFeatures
      */
     public function getFeatures()
     {
@@ -274,11 +272,11 @@ class CreateCheckoutRequest implements ArrayAccess
     /**
      * Sets features.
      *
-     * @param \zipMoney\Model\CreateCheckoutRequestFeatures $features
+     * @param CreateCheckoutRequestFeatures $features
      *
      * @return $this
      */
-    public function setFeatures($features)
+    public function setFeatures($features): static
     {
         $this->container['features'] = $features;
 
@@ -288,7 +286,7 @@ class CreateCheckoutRequest implements ArrayAccess
     /**
      * Gets metadata.
      *
-     * @return \zipMoney\Model\Metadata
+     * @return Metadata
      */
     public function getMetadata()
     {
@@ -298,11 +296,11 @@ class CreateCheckoutRequest implements ArrayAccess
     /**
      * Sets metadata.
      *
-     * @param \zipMoney\Model\Metadata $metadata
+     * @param Metadata $metadata
      *
      * @return $this
      */
-    public function setMetadata($metadata)
+    public function setMetadata($metadata): static
     {
         $this->container['metadata'] = $metadata;
 
@@ -312,7 +310,7 @@ class CreateCheckoutRequest implements ArrayAccess
     /**
      * Gets config.
      *
-     * @return \zipMoney\Model\CheckoutConfiguration
+     * @return CheckoutConfiguration
      */
     public function getConfig()
     {
@@ -322,11 +320,11 @@ class CreateCheckoutRequest implements ArrayAccess
     /**
      * Sets config.
      *
-     * @param \zipMoney\Model\CheckoutConfiguration $config
+     * @param CheckoutConfiguration $config
      *
      * @return $this
      */
-    public function setConfig($config)
+    public function setConfig($config): static
     {
         $this->container['config'] = $config;
 
@@ -337,8 +335,6 @@ class CreateCheckoutRequest implements ArrayAccess
      * Returns true if offset exists. False otherwise.
      *
      * @param int $offset Offset
-     *
-     * @return bool
      */
     public function offsetExists($offset): bool
     {
@@ -349,8 +345,6 @@ class CreateCheckoutRequest implements ArrayAccess
      * Gets offset.
      *
      * @param int $offset Offset
-     *
-     * @return mixed
      */
     public function offsetGet($offset): mixed
     {
@@ -363,7 +357,7 @@ class CreateCheckoutRequest implements ArrayAccess
      * @param int   $offset Offset
      * @param mixed $value  Value to be set
      */
-    public function offsetSet($offset, $value): void
+    public function offsetSet($offset, mixed $value): void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -384,15 +378,13 @@ class CreateCheckoutRequest implements ArrayAccess
 
     /**
      * Gets the string presentation of the object.
-     *
-     * @return string
      */
-    public function __toString()
+    public function __toString(): string
     {
         if (defined('JSON_PRETTY_PRINT')) { // use JSON pretty print
-            return json_encode(\zipMoney\ObjectSerializer::sanitizeForSerialization($this), JSON_PRETTY_PRINT);
+            return (string) json_encode(ObjectSerializer::sanitizeForSerialization($this), JSON_PRETTY_PRINT);
         }
 
-        return json_encode(\zipMoney\ObjectSerializer::sanitizeForSerialization($this));
+        return (string) json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }

--- a/lib/Model/CreateCheckoutRequestFeatures.php
+++ b/lib/Model/CreateCheckoutRequestFeatures.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 /**
@@ -13,8 +14,9 @@ declare(strict_types=1);
 namespace zipMoney\Model;
 
 use ArrayAccess;
+use zipMoney\ObjectSerializer;
 
-class CreateCheckoutRequestFeatures implements ArrayAccess
+class CreateCheckoutRequestFeatures implements ArrayAccess, \Stringable
 {
     public const DISCRIMINATOR = 'subclass';
 
@@ -95,7 +97,7 @@ class CreateCheckoutRequestFeatures implements ArrayAccess
      */
     public function __construct(?array $data = null)
     {
-        $this->container['tokenisation'] = isset($data['tokenisation']) ? $data['tokenisation'] : null;
+        $this->container['tokenisation'] = $data['tokenisation'] ?? null;
     }
 
     /**
@@ -103,7 +105,7 @@ class CreateCheckoutRequestFeatures implements ArrayAccess
      *
      * @return array invalid properties with reasons
      */
-    public function listInvalidProperties()
+    public function listInvalidProperties(): array
     {
         return [];
     }
@@ -114,7 +116,7 @@ class CreateCheckoutRequestFeatures implements ArrayAccess
      *
      * @return bool True if all properties are valid
      */
-    public function valid()
+    public function valid(): bool
     {
         return true;
     }
@@ -122,7 +124,7 @@ class CreateCheckoutRequestFeatures implements ArrayAccess
     /**
      * Gets tokenisation.
      *
-     * @return \zipMoney\Model\CreateCheckoutRequestFeaturesTokenisation
+     * @return CreateCheckoutRequestFeaturesTokenisation
      */
     public function getTokenisation()
     {
@@ -132,11 +134,11 @@ class CreateCheckoutRequestFeatures implements ArrayAccess
     /**
      * Sets tokenisation.
      *
-     * @param \zipMoney\Model\CreateCheckoutRequestFeaturesTokenisation $tokenisation
+     * @param CreateCheckoutRequestFeaturesTokenisation $tokenisation
      *
      * @return $this
      */
-    public function setTokenisation($tokenisation)
+    public function setTokenisation($tokenisation): static
     {
         $this->container['tokenisation'] = $tokenisation;
 
@@ -147,8 +149,6 @@ class CreateCheckoutRequestFeatures implements ArrayAccess
      * Returns true if offset exists. False otherwise.
      *
      * @param int $offset Offset
-     *
-     * @return bool
      */
     public function offsetExists($offset): bool
     {
@@ -159,8 +159,6 @@ class CreateCheckoutRequestFeatures implements ArrayAccess
      * Gets offset.
      *
      * @param int $offset Offset
-     *
-     * @return mixed
      */
     public function offsetGet($offset): mixed
     {
@@ -173,7 +171,7 @@ class CreateCheckoutRequestFeatures implements ArrayAccess
      * @param int   $offset Offset
      * @param mixed $value  Value to be set
      */
-    public function offsetSet($offset, $value): void
+    public function offsetSet($offset, mixed $value): void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -194,15 +192,13 @@ class CreateCheckoutRequestFeatures implements ArrayAccess
 
     /**
      * Gets the string presentation of the object.
-     *
-     * @return string
      */
-    public function __toString()
+    public function __toString(): string
     {
         if (defined('JSON_PRETTY_PRINT')) { // use JSON pretty print
-            return json_encode(\zipMoney\ObjectSerializer::sanitizeForSerialization($this), JSON_PRETTY_PRINT);
+            return (string) json_encode(ObjectSerializer::sanitizeForSerialization($this), JSON_PRETTY_PRINT);
         }
 
-        return json_encode(\zipMoney\ObjectSerializer::sanitizeForSerialization($this));
+        return (string) json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }

--- a/lib/Model/CreateCheckoutRequestFeaturesTokenisation.php
+++ b/lib/Model/CreateCheckoutRequestFeaturesTokenisation.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 /**
@@ -13,8 +14,9 @@ declare(strict_types=1);
 namespace zipMoney\Model;
 
 use ArrayAccess;
+use zipMoney\ObjectSerializer;
 
-class CreateCheckoutRequestFeaturesTokenisation implements ArrayAccess
+class CreateCheckoutRequestFeaturesTokenisation implements ArrayAccess, \Stringable
 {
     public const DISCRIMINATOR = 'subclass';
 
@@ -95,7 +97,7 @@ class CreateCheckoutRequestFeaturesTokenisation implements ArrayAccess
      */
     public function __construct(?array $data = null)
     {
-        $this->container['required'] = isset($data['required']) ? $data['required'] : false;
+        $this->container['required'] = $data['required'] ?? false;
     }
 
     /**
@@ -103,7 +105,7 @@ class CreateCheckoutRequestFeaturesTokenisation implements ArrayAccess
      *
      * @return array invalid properties with reasons
      */
-    public function listInvalidProperties()
+    public function listInvalidProperties(): array
     {
         $invalid_properties = [];
 
@@ -120,13 +122,9 @@ class CreateCheckoutRequestFeaturesTokenisation implements ArrayAccess
      *
      * @return bool True if all properties are valid
      */
-    public function valid()
+    public function valid(): bool
     {
-        if ($this->container['required'] === null) {
-            return false;
-        }
-
-        return true;
+        return $this->container['required'] !== null;
     }
 
     /**
@@ -146,7 +144,7 @@ class CreateCheckoutRequestFeaturesTokenisation implements ArrayAccess
      *
      * @return $this
      */
-    public function setRequired($required)
+    public function setRequired($required): static
     {
         $this->container['required'] = $required;
 
@@ -157,8 +155,6 @@ class CreateCheckoutRequestFeaturesTokenisation implements ArrayAccess
      * Returns true if offset exists. False otherwise.
      *
      * @param int $offset Offset
-     *
-     * @return bool
      */
     public function offsetExists($offset): bool
     {
@@ -169,8 +165,6 @@ class CreateCheckoutRequestFeaturesTokenisation implements ArrayAccess
      * Gets offset.
      *
      * @param int $offset Offset
-     *
-     * @return mixed
      */
     public function offsetGet($offset): mixed
     {
@@ -183,7 +177,7 @@ class CreateCheckoutRequestFeaturesTokenisation implements ArrayAccess
      * @param int   $offset Offset
      * @param mixed $value  Value to be set
      */
-    public function offsetSet($offset, $value): void
+    public function offsetSet($offset, mixed $value): void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -204,15 +198,13 @@ class CreateCheckoutRequestFeaturesTokenisation implements ArrayAccess
 
     /**
      * Gets the string presentation of the object.
-     *
-     * @return string
      */
-    public function __toString()
+    public function __toString(): string
     {
         if (defined('JSON_PRETTY_PRINT')) { // use JSON pretty print
-            return json_encode(\zipMoney\ObjectSerializer::sanitizeForSerialization($this), JSON_PRETTY_PRINT);
+            return (string) json_encode(ObjectSerializer::sanitizeForSerialization($this), JSON_PRETTY_PRINT);
         }
 
-        return json_encode(\zipMoney\ObjectSerializer::sanitizeForSerialization($this));
+        return (string) json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }

--- a/lib/Model/CreateRefundRequest.php
+++ b/lib/Model/CreateRefundRequest.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 /**
@@ -13,8 +14,9 @@ declare(strict_types=1);
 namespace zipMoney\Model;
 
 use ArrayAccess;
+use zipMoney\ObjectSerializer;
 
-class CreateRefundRequest implements ArrayAccess
+class CreateRefundRequest implements ArrayAccess, \Stringable
 {
     public const DISCRIMINATOR = 'subclass';
 
@@ -107,10 +109,10 @@ class CreateRefundRequest implements ArrayAccess
      */
     public function __construct(?array $data = null)
     {
-        $this->container['charge_id'] = isset($data['charge_id']) ? $data['charge_id'] : null;
-        $this->container['reason'] = isset($data['reason']) ? $data['reason'] : null;
-        $this->container['amount'] = isset($data['amount']) ? $data['amount'] : null;
-        $this->container['metadata'] = isset($data['metadata']) ? $data['metadata'] : null;
+        $this->container['charge_id'] = $data['charge_id'] ?? null;
+        $this->container['reason'] = $data['reason'] ?? null;
+        $this->container['amount'] = $data['amount'] ?? null;
+        $this->container['metadata'] = $data['metadata'] ?? null;
     }
 
     /**
@@ -118,7 +120,7 @@ class CreateRefundRequest implements ArrayAccess
      *
      * @return array invalid properties with reasons
      */
-    public function listInvalidProperties()
+    public function listInvalidProperties(): array
     {
         $invalid_properties = [];
 
@@ -155,11 +157,7 @@ class CreateRefundRequest implements ArrayAccess
         if ($this->container['amount'] === null) {
             return false;
         }
-        if ($this->container['amount'] < 0) {
-            return false;
-        }
-
-        return true;
+        return $this->container['amount'] >= 0;
     }
 
     /**
@@ -179,7 +177,7 @@ class CreateRefundRequest implements ArrayAccess
      *
      * @return $this
      */
-    public function setChargeId($charge_id)
+    public function setChargeId($charge_id): static
     {
         $this->container['charge_id'] = $charge_id;
 
@@ -203,7 +201,7 @@ class CreateRefundRequest implements ArrayAccess
      *
      * @return $this
      */
-    public function setReason($reason)
+    public function setReason($reason): static
     {
         $this->container['reason'] = $reason;
 
@@ -227,7 +225,7 @@ class CreateRefundRequest implements ArrayAccess
      *
      * @return $this
      */
-    public function setAmount($amount)
+    public function setAmount($amount): static
     {
         if (($amount < 0)) {
             throw new \InvalidArgumentException('invalid value for $amount when calling CreateRefundRequest., must be bigger than or equal to 0.');
@@ -255,7 +253,7 @@ class CreateRefundRequest implements ArrayAccess
      *
      * @return $this
      */
-    public function setMetadata($metadata)
+    public function setMetadata($metadata): static
     {
         $this->container['metadata'] = $metadata;
 
@@ -266,8 +264,6 @@ class CreateRefundRequest implements ArrayAccess
      * Returns true if offset exists. False otherwise.
      *
      * @param int $offset Offset
-     *
-     * @return bool
      */
     public function offsetExists($offset): bool
     {
@@ -278,8 +274,6 @@ class CreateRefundRequest implements ArrayAccess
      * Gets offset.
      *
      * @param int $offset Offset
-     *
-     * @return mixed
      */
     public function offsetGet($offset): mixed
     {
@@ -292,7 +286,7 @@ class CreateRefundRequest implements ArrayAccess
      * @param int   $offset Offset
      * @param mixed $value  Value to be set
      */
-    public function offsetSet($offset, $value): void
+    public function offsetSet($offset, mixed $value): void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -313,15 +307,13 @@ class CreateRefundRequest implements ArrayAccess
 
     /**
      * Gets the string presentation of the object.
-     *
-     * @return string
      */
-    public function __toString()
+    public function __toString(): string
     {
         if (defined('JSON_PRETTY_PRINT')) { // use JSON pretty print
-            return json_encode(\zipMoney\ObjectSerializer::sanitizeForSerialization($this), JSON_PRETTY_PRINT);
+            return (string) json_encode(ObjectSerializer::sanitizeForSerialization($this), JSON_PRETTY_PRINT);
         }
 
-        return json_encode(\zipMoney\ObjectSerializer::sanitizeForSerialization($this));
+        return (string) json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }

--- a/lib/Model/CreateTokenRequest.php
+++ b/lib/Model/CreateTokenRequest.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 /**
@@ -13,8 +14,9 @@ declare(strict_types=1);
 namespace zipMoney\Model;
 
 use ArrayAccess;
+use zipMoney\ObjectSerializer;
 
-class CreateTokenRequest implements ArrayAccess
+class CreateTokenRequest implements ArrayAccess, \Stringable
 {
     public const DISCRIMINATOR = 'subclass';
 
@@ -95,7 +97,7 @@ class CreateTokenRequest implements ArrayAccess
      */
     public function __construct(?array $data = null)
     {
-        $this->container['authority'] = isset($data['authority']) ? $data['authority'] : null;
+        $this->container['authority'] = $data['authority'] ?? null;
     }
 
     /**
@@ -103,7 +105,7 @@ class CreateTokenRequest implements ArrayAccess
      *
      * @return array invalid properties with reasons
      */
-    public function listInvalidProperties()
+    public function listInvalidProperties(): array
     {
         $invalid_properties = [];
 
@@ -120,19 +122,15 @@ class CreateTokenRequest implements ArrayAccess
      *
      * @return bool True if all properties are valid
      */
-    public function valid()
+    public function valid(): bool
     {
-        if ($this->container['authority'] === null) {
-            return false;
-        }
-
-        return true;
+        return $this->container['authority'] !== null;
     }
 
     /**
      * Gets authority.
      *
-     * @return \zipMoney\Model\Authority
+     * @return Authority
      */
     public function getAuthority()
     {
@@ -142,11 +140,11 @@ class CreateTokenRequest implements ArrayAccess
     /**
      * Sets authority.
      *
-     * @param \zipMoney\Model\Authority $authority
+     * @param Authority $authority
      *
      * @return $this
      */
-    public function setAuthority($authority)
+    public function setAuthority($authority): static
     {
         $this->container['authority'] = $authority;
 
@@ -157,8 +155,6 @@ class CreateTokenRequest implements ArrayAccess
      * Returns true if offset exists. False otherwise.
      *
      * @param int $offset Offset
-     *
-     * @return bool
      */
     public function offsetExists($offset): bool
     {
@@ -169,8 +165,6 @@ class CreateTokenRequest implements ArrayAccess
      * Gets offset.
      *
      * @param int $offset Offset
-     *
-     * @return mixed
      */
     public function offsetGet($offset): mixed
     {
@@ -183,7 +177,7 @@ class CreateTokenRequest implements ArrayAccess
      * @param int   $offset Offset
      * @param mixed $value  Value to be set
      */
-    public function offsetSet($offset, $value): void
+    public function offsetSet($offset, mixed $value): void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -204,15 +198,13 @@ class CreateTokenRequest implements ArrayAccess
 
     /**
      * Gets the string presentation of the object.
-     *
-     * @return string
      */
-    public function __toString()
+    public function __toString(): string
     {
         if (defined('JSON_PRETTY_PRINT')) { // use JSON pretty print
-            return json_encode(\zipMoney\ObjectSerializer::sanitizeForSerialization($this), JSON_PRETTY_PRINT);
+            return (string) json_encode(ObjectSerializer::sanitizeForSerialization($this), JSON_PRETTY_PRINT);
         }
 
-        return json_encode(\zipMoney\ObjectSerializer::sanitizeForSerialization($this));
+        return (string) json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }

--- a/lib/Model/CurrencyUtil.php
+++ b/lib/Model/CurrencyUtil.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 /**
@@ -24,7 +25,7 @@ class CurrencyUtil
     /**
      * Gets all available regions.
      */
-    public static function getAvailableRegions()
+    public static function getAvailableRegions(): array
     {
         return [
             'au' => 'Australia',
@@ -39,12 +40,9 @@ class CurrencyUtil
         ];
     }
 
-    public static function isValidCurrency($currency)
+    public static function isValidCurrency($currency): array
     {
-        $result = array(
-            'valid' => true,
-            'message' => '',
-        );
+        $result = ['valid' => true, 'message' => ''];
         $allowed_values = self::getAllowedCurrencyList();
         if (!in_array($currency, $allowed_values)) {
             $result['valid'] = false;
@@ -57,12 +55,8 @@ class CurrencyUtil
      * Gets allowable values of the enum
      * @return string[]
      */
-    private static function getAllowedCurrencyList()
+    private static function getAllowedCurrencyList(): array
     {
-        return array(
-            self::CURRENCY_AUD,
-            self::CURRENCY_NZD,
-            self::CURRENCY_USD,
-        );
+        return [self::CURRENCY_AUD, self::CURRENCY_NZD, self::CURRENCY_USD];
     }
 }

--- a/lib/Model/Customer.php
+++ b/lib/Model/Customer.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 /**
@@ -13,8 +14,9 @@ declare(strict_types=1);
 namespace zipMoney\Model;
 
 use ArrayAccess;
+use zipMoney\ObjectSerializer;
 
-class Customer implements ArrayAccess
+class Customer implements ArrayAccess, \Stringable
 {
     public const DISCRIMINATOR = 'subclass';
 
@@ -118,7 +120,7 @@ class Customer implements ArrayAccess
      *
      * @return string[]
      */
-    public function getGenderAllowableValues()
+    public function getGenderAllowableValues(): array
     {
         return [
             self::GENDER_MALE,
@@ -141,14 +143,14 @@ class Customer implements ArrayAccess
      */
     public function __construct(?array $data = null)
     {
-        $this->container['title'] = isset($data['title']) ? $data['title'] : null;
-        $this->container['first_name'] = isset($data['first_name']) ? $data['first_name'] : null;
-        $this->container['middle_name'] = isset($data['middle_name']) ? $data['middle_name'] : null;
-        $this->container['last_name'] = isset($data['last_name']) ? $data['last_name'] : null;
-        $this->container['phone'] = isset($data['phone']) ? $data['phone'] : null;
-        $this->container['email'] = isset($data['email']) ? $data['email'] : null;
-        $this->container['birth_date'] = isset($data['birth_date']) ? $data['birth_date'] : null;
-        $this->container['gender'] = isset($data['gender']) ? $data['gender'] : null;
+        $this->container['title'] = $data['title'] ?? null;
+        $this->container['first_name'] = $data['first_name'] ?? null;
+        $this->container['middle_name'] = $data['middle_name'] ?? null;
+        $this->container['last_name'] = $data['last_name'] ?? null;
+        $this->container['phone'] = $data['phone'] ?? null;
+        $this->container['email'] = $data['email'] ?? null;
+        $this->container['birth_date'] = $data['birth_date'] ?? null;
+        $this->container['gender'] = $data['gender'] ?? null;
     }
 
     /**
@@ -156,7 +158,7 @@ class Customer implements ArrayAccess
      *
      * @return array invalid properties with reasons
      */
-    public function listInvalidProperties()
+    public function listInvalidProperties(): array
     {
         $invalid_properties = [];
 
@@ -207,11 +209,7 @@ class Customer implements ArrayAccess
             return false;
         }
         $allowed_values = ['Male', 'Female', 'Other'];
-        if (!in_array($this->container['gender'], $allowed_values)) {
-            return false;
-        }
-
-        return true;
+        return in_array($this->container['gender'], $allowed_values);
     }
 
     /**
@@ -231,7 +229,7 @@ class Customer implements ArrayAccess
      *
      * @return $this
      */
-    public function setTitle($title)
+    public function setTitle($title): static
     {
         $this->container['title'] = $title;
 
@@ -255,7 +253,7 @@ class Customer implements ArrayAccess
      *
      * @return $this
      */
-    public function setFirstName($first_name)
+    public function setFirstName($first_name): static
     {
         $this->container['first_name'] = $first_name;
 
@@ -279,7 +277,7 @@ class Customer implements ArrayAccess
      *
      * @return $this
      */
-    public function setMiddleName($middle_name)
+    public function setMiddleName($middle_name): static
     {
         $this->container['middle_name'] = $middle_name;
 
@@ -303,7 +301,7 @@ class Customer implements ArrayAccess
      *
      * @return $this
      */
-    public function setLastName($last_name)
+    public function setLastName($last_name): static
     {
         $this->container['last_name'] = $last_name;
 
@@ -327,7 +325,7 @@ class Customer implements ArrayAccess
      *
      * @return $this
      */
-    public function setPhone($phone)
+    public function setPhone($phone): static
     {
         $this->container['phone'] = $phone;
 
@@ -351,7 +349,7 @@ class Customer implements ArrayAccess
      *
      * @return $this
      */
-    public function setEmail($email)
+    public function setEmail($email): static
     {
         $this->container['email'] = $email;
 
@@ -375,7 +373,7 @@ class Customer implements ArrayAccess
      *
      * @return $this
      */
-    public function setBirthDate($birth_date)
+    public function setBirthDate($birth_date): static
     {
         $this->container['birth_date'] = $birth_date;
 
@@ -399,7 +397,7 @@ class Customer implements ArrayAccess
      *
      * @return $this
      */
-    public function setGender($gender)
+    public function setGender($gender): static
     {
         $allowed_values = ['Male', 'Female', 'Other'];
         if (!is_null($gender) && (!in_array($gender, $allowed_values))) {
@@ -414,8 +412,6 @@ class Customer implements ArrayAccess
      * Returns true if offset exists. False otherwise.
      *
      * @param int $offset Offset
-     *
-     * @return bool
      */
     public function offsetExists($offset): bool
     {
@@ -426,8 +422,6 @@ class Customer implements ArrayAccess
      * Gets offset.
      *
      * @param int $offset Offset
-     *
-     * @return mixed
      */
     public function offsetGet($offset): mixed
     {
@@ -440,7 +434,7 @@ class Customer implements ArrayAccess
      * @param int   $offset Offset
      * @param mixed $value  Value to be set
      */
-    public function offsetSet($offset, $value): void
+    public function offsetSet($offset, mixed $value): void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -461,15 +455,13 @@ class Customer implements ArrayAccess
 
     /**
      * Gets the string presentation of the object.
-     *
-     * @return string
      */
-    public function __toString()
+    public function __toString(): string
     {
         if (defined('JSON_PRETTY_PRINT')) { // use JSON pretty print
-            return json_encode(\zipMoney\ObjectSerializer::sanitizeForSerialization($this), JSON_PRETTY_PRINT);
+            return (string) json_encode(ObjectSerializer::sanitizeForSerialization($this), JSON_PRETTY_PRINT);
         }
 
-        return json_encode(\zipMoney\ObjectSerializer::sanitizeForSerialization($this));
+        return (string) json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }

--- a/lib/Model/ErrorResponse.php
+++ b/lib/Model/ErrorResponse.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 /**
@@ -13,8 +14,9 @@ declare(strict_types=1);
 namespace zipMoney\Model;
 
 use ArrayAccess;
+use zipMoney\ObjectSerializer;
 
-class ErrorResponse implements ArrayAccess
+class ErrorResponse implements ArrayAccess, \Stringable
 {
     public const DISCRIMINATOR = 'subclass';
 
@@ -95,7 +97,7 @@ class ErrorResponse implements ArrayAccess
      */
     public function __construct(?array $data = null)
     {
-        $this->container['error'] = isset($data['error']) ? $data['error'] : null;
+        $this->container['error'] = $data['error'] ?? null;
     }
 
     /**
@@ -103,7 +105,7 @@ class ErrorResponse implements ArrayAccess
      *
      * @return array invalid properties with reasons
      */
-    public function listInvalidProperties()
+    public function listInvalidProperties(): array
     {
         return [];
     }
@@ -114,7 +116,7 @@ class ErrorResponse implements ArrayAccess
      *
      * @return bool True if all properties are valid
      */
-    public function valid()
+    public function valid(): bool
     {
         return true;
     }
@@ -122,7 +124,7 @@ class ErrorResponse implements ArrayAccess
     /**
      * Gets error.
      *
-     * @return \zipMoney\Model\ErrorResponseError
+     * @return ErrorResponseError
      */
     public function getError()
     {
@@ -132,11 +134,11 @@ class ErrorResponse implements ArrayAccess
     /**
      * Sets error.
      *
-     * @param \zipMoney\Model\ErrorResponseError $error
+     * @param ErrorResponseError $error
      *
      * @return $this
      */
-    public function setError($error)
+    public function setError($error): static
     {
         $this->container['error'] = $error;
 
@@ -147,8 +149,6 @@ class ErrorResponse implements ArrayAccess
      * Returns true if offset exists. False otherwise.
      *
      * @param int $offset Offset
-     *
-     * @return bool
      */
     public function offsetExists($offset): bool
     {
@@ -159,8 +159,6 @@ class ErrorResponse implements ArrayAccess
      * Gets offset.
      *
      * @param int $offset Offset
-     *
-     * @return mixed
      */
     public function offsetGet($offset): mixed
     {
@@ -173,7 +171,7 @@ class ErrorResponse implements ArrayAccess
      * @param int   $offset Offset
      * @param mixed $value  Value to be set
      */
-    public function offsetSet($offset, $value): void
+    public function offsetSet($offset, mixed $value): void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -194,15 +192,13 @@ class ErrorResponse implements ArrayAccess
 
     /**
      * Gets the string presentation of the object.
-     *
-     * @return string
      */
-    public function __toString()
+    public function __toString(): string
     {
         if (defined('JSON_PRETTY_PRINT')) { // use JSON pretty print
-            return json_encode(\zipMoney\ObjectSerializer::sanitizeForSerialization($this), JSON_PRETTY_PRINT);
+            return (string) json_encode(ObjectSerializer::sanitizeForSerialization($this), JSON_PRETTY_PRINT);
         }
 
-        return json_encode(\zipMoney\ObjectSerializer::sanitizeForSerialization($this));
+        return (string) json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }

--- a/lib/Model/ErrorResponseError.php
+++ b/lib/Model/ErrorResponseError.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 /**
@@ -13,8 +14,9 @@ declare(strict_types=1);
 namespace zipMoney\Model;
 
 use ArrayAccess;
+use zipMoney\ObjectSerializer;
 
-class ErrorResponseError implements ArrayAccess
+class ErrorResponseError implements ArrayAccess, \Stringable
 {
     public const DISCRIMINATOR = 'subclass';
 
@@ -103,9 +105,9 @@ class ErrorResponseError implements ArrayAccess
      */
     public function __construct(?array $data = null)
     {
-        $this->container['code'] = isset($data['code']) ? $data['code'] : null;
-        $this->container['message'] = isset($data['message']) ? $data['message'] : null;
-        $this->container['details'] = isset($data['details']) ? $data['details'] : null;
+        $this->container['code'] = $data['code'] ?? null;
+        $this->container['message'] = $data['message'] ?? null;
+        $this->container['details'] = $data['details'] ?? null;
     }
 
     /**
@@ -113,7 +115,7 @@ class ErrorResponseError implements ArrayAccess
      *
      * @return array invalid properties with reasons
      */
-    public function listInvalidProperties()
+    public function listInvalidProperties(): array
     {
         $invalid_properties = [];
 
@@ -138,11 +140,7 @@ class ErrorResponseError implements ArrayAccess
         if ($this->container['code'] === null) {
             return false;
         }
-        if ($this->container['message'] === null) {
-            return false;
-        }
-
-        return true;
+        return $this->container['message'] !== null;
     }
 
     /**
@@ -162,7 +160,7 @@ class ErrorResponseError implements ArrayAccess
      *
      * @return $this
      */
-    public function setCode($code)
+    public function setCode($code): static
     {
         $this->container['code'] = $code;
 
@@ -186,7 +184,7 @@ class ErrorResponseError implements ArrayAccess
      *
      * @return $this
      */
-    public function setMessage($message)
+    public function setMessage($message): static
     {
         $this->container['message'] = $message;
 
@@ -196,7 +194,7 @@ class ErrorResponseError implements ArrayAccess
     /**
      * Gets details.
      *
-     * @return \zipMoney\Model\ErrorResponseErrorDetails[]
+     * @return ErrorResponseErrorDetails[]
      */
     public function getDetails()
     {
@@ -206,11 +204,11 @@ class ErrorResponseError implements ArrayAccess
     /**
      * Sets details.
      *
-     * @param \zipMoney\Model\ErrorResponseErrorDetails[] $details
+     * @param ErrorResponseErrorDetails[] $details
      *
      * @return $this
      */
-    public function setDetails($details)
+    public function setDetails($details): static
     {
         $this->container['details'] = $details;
 
@@ -221,8 +219,6 @@ class ErrorResponseError implements ArrayAccess
      * Returns true if offset exists. False otherwise.
      *
      * @param int $offset Offset
-     *
-     * @return bool
      */
     public function offsetExists($offset): bool
     {
@@ -233,8 +229,6 @@ class ErrorResponseError implements ArrayAccess
      * Gets offset.
      *
      * @param int $offset Offset
-     *
-     * @return mixed
      */
     public function offsetGet($offset): mixed
     {
@@ -247,7 +241,7 @@ class ErrorResponseError implements ArrayAccess
      * @param int   $offset Offset
      * @param mixed $value  Value to be set
      */
-    public function offsetSet($offset, $value): void
+    public function offsetSet($offset, mixed $value): void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -268,15 +262,13 @@ class ErrorResponseError implements ArrayAccess
 
     /**
      * Gets the string presentation of the object.
-     *
-     * @return string
      */
-    public function __toString()
+    public function __toString(): string
     {
         if (defined('JSON_PRETTY_PRINT')) { // use JSON pretty print
-            return json_encode(\zipMoney\ObjectSerializer::sanitizeForSerialization($this), JSON_PRETTY_PRINT);
+            return (string) json_encode(ObjectSerializer::sanitizeForSerialization($this), JSON_PRETTY_PRINT);
         }
 
-        return json_encode(\zipMoney\ObjectSerializer::sanitizeForSerialization($this));
+        return (string) json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }

--- a/lib/Model/ErrorResponseErrorDetails.php
+++ b/lib/Model/ErrorResponseErrorDetails.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 /**
@@ -13,8 +14,9 @@ declare(strict_types=1);
 namespace zipMoney\Model;
 
 use ArrayAccess;
+use zipMoney\ObjectSerializer;
 
-class ErrorResponseErrorDetails implements ArrayAccess
+class ErrorResponseErrorDetails implements ArrayAccess, \Stringable
 {
     public const DISCRIMINATOR = 'subclass';
 
@@ -99,8 +101,8 @@ class ErrorResponseErrorDetails implements ArrayAccess
      */
     public function __construct(?array $data = null)
     {
-        $this->container['name'] = isset($data['name']) ? $data['name'] : null;
-        $this->container['message'] = isset($data['message']) ? $data['message'] : null;
+        $this->container['name'] = $data['name'] ?? null;
+        $this->container['message'] = $data['message'] ?? null;
     }
 
     /**
@@ -108,7 +110,7 @@ class ErrorResponseErrorDetails implements ArrayAccess
      *
      * @return array invalid properties with reasons
      */
-    public function listInvalidProperties()
+    public function listInvalidProperties(): array
     {
         return [];
     }
@@ -119,7 +121,7 @@ class ErrorResponseErrorDetails implements ArrayAccess
      *
      * @return bool True if all properties are valid
      */
-    public function valid()
+    public function valid(): bool
     {
         return true;
     }
@@ -141,7 +143,7 @@ class ErrorResponseErrorDetails implements ArrayAccess
      *
      * @return $this
      */
-    public function setName($name)
+    public function setName($name): static
     {
         $this->container['name'] = $name;
 
@@ -165,7 +167,7 @@ class ErrorResponseErrorDetails implements ArrayAccess
      *
      * @return $this
      */
-    public function setMessage($message)
+    public function setMessage($message): static
     {
         $this->container['message'] = $message;
 
@@ -176,8 +178,6 @@ class ErrorResponseErrorDetails implements ArrayAccess
      * Returns true if offset exists. False otherwise.
      *
      * @param int $offset Offset
-     *
-     * @return bool
      */
     public function offsetExists($offset): bool
     {
@@ -188,8 +188,6 @@ class ErrorResponseErrorDetails implements ArrayAccess
      * Gets offset.
      *
      * @param int $offset Offset
-     *
-     * @return mixed
      */
     public function offsetGet($offset): mixed
     {
@@ -202,7 +200,7 @@ class ErrorResponseErrorDetails implements ArrayAccess
      * @param int   $offset Offset
      * @param mixed $value  Value to be set
      */
-    public function offsetSet($offset, $value): void
+    public function offsetSet($offset, mixed $value): void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -223,15 +221,13 @@ class ErrorResponseErrorDetails implements ArrayAccess
 
     /**
      * Gets the string presentation of the object.
-     *
-     * @return string
      */
-    public function __toString()
+    public function __toString(): string
     {
         if (defined('JSON_PRETTY_PRINT')) { // use JSON pretty print
-            return json_encode(\zipMoney\ObjectSerializer::sanitizeForSerialization($this), JSON_PRETTY_PRINT);
+            return (string) json_encode(ObjectSerializer::sanitizeForSerialization($this), JSON_PRETTY_PRINT);
         }
 
-        return json_encode(\zipMoney\ObjectSerializer::sanitizeForSerialization($this));
+        return (string) json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }

--- a/lib/Model/Flightadditionaldetails.php
+++ b/lib/Model/Flightadditionaldetails.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 /**
@@ -13,8 +14,9 @@ declare(strict_types=1);
 namespace zipMoney\Model;
 
 use ArrayAccess;
+use zipMoney\ObjectSerializer;
 
-class Flightadditionaldetails implements ArrayAccess
+class Flightadditionaldetails implements ArrayAccess, \Stringable
 {
     public const DISCRIMINATOR = 'subclass';
 
@@ -127,15 +129,15 @@ class Flightadditionaldetails implements ArrayAccess
      */
     public function __construct(?array $data = null)
     {
-        $this->container['departure_date'] = isset($data['departure_date']) ? $data['departure_date'] : null;
-        $this->container['flight_number'] = isset($data['flight_number']) ? $data['flight_number'] : null;
-        $this->container['aircraft_type'] = isset($data['aircraft_type']) ? $data['aircraft_type'] : null;
-        $this->container['class'] = isset($data['class']) ? $data['class'] : null;
-        $this->container['origin'] = isset($data['origin']) ? $data['origin'] : null;
-        $this->container['destination'] = isset($data['destination']) ? $data['destination'] : null;
-        $this->container['duration'] = isset($data['duration']) ? $data['duration'] : null;
-        $this->container['passengers'] = isset($data['passengers']) ? $data['passengers'] : null;
-        $this->container['stopovers'] = isset($data['stopovers']) ? $data['stopovers'] : null;
+        $this->container['departure_date'] = $data['departure_date'] ?? null;
+        $this->container['flight_number'] = $data['flight_number'] ?? null;
+        $this->container['aircraft_type'] = $data['aircraft_type'] ?? null;
+        $this->container['class'] = $data['class'] ?? null;
+        $this->container['origin'] = $data['origin'] ?? null;
+        $this->container['destination'] = $data['destination'] ?? null;
+        $this->container['duration'] = $data['duration'] ?? null;
+        $this->container['passengers'] = $data['passengers'] ?? null;
+        $this->container['stopovers'] = $data['stopovers'] ?? null;
     }
 
     /**
@@ -143,7 +145,7 @@ class Flightadditionaldetails implements ArrayAccess
      *
      * @return array invalid properties with reasons
      */
-    public function listInvalidProperties()
+    public function listInvalidProperties(): array
     {
         $invalid_properties = [];
 
@@ -160,13 +162,9 @@ class Flightadditionaldetails implements ArrayAccess
      *
      * @return bool True if all properties are valid
      */
-    public function valid()
+    public function valid(): bool
     {
-        if ($this->container['departure_date'] === null) {
-            return false;
-        }
-
-        return true;
+        return $this->container['departure_date'] !== null;
     }
 
     /**
@@ -186,7 +184,7 @@ class Flightadditionaldetails implements ArrayAccess
      *
      * @return $this
      */
-    public function setDepartureDate($departure_date)
+    public function setDepartureDate($departure_date): static
     {
         $this->container['departure_date'] = $departure_date;
 
@@ -210,7 +208,7 @@ class Flightadditionaldetails implements ArrayAccess
      *
      * @return $this
      */
-    public function setFlightNumber($flight_number)
+    public function setFlightNumber($flight_number): static
     {
         $this->container['flight_number'] = $flight_number;
 
@@ -234,7 +232,7 @@ class Flightadditionaldetails implements ArrayAccess
      *
      * @return $this
      */
-    public function setAircraftType($aircraft_type)
+    public function setAircraftType($aircraft_type): static
     {
         $this->container['aircraft_type'] = $aircraft_type;
 
@@ -258,7 +256,7 @@ class Flightadditionaldetails implements ArrayAccess
      *
      * @return $this
      */
-    public function setClass($class)
+    public function setClass($class): static
     {
         $this->container['class'] = $class;
 
@@ -282,7 +280,7 @@ class Flightadditionaldetails implements ArrayAccess
      *
      * @return $this
      */
-    public function setOrigin($origin)
+    public function setOrigin($origin): static
     {
         $this->container['origin'] = $origin;
 
@@ -306,7 +304,7 @@ class Flightadditionaldetails implements ArrayAccess
      *
      * @return $this
      */
-    public function setDestination($destination)
+    public function setDestination($destination): static
     {
         $this->container['destination'] = $destination;
 
@@ -330,7 +328,7 @@ class Flightadditionaldetails implements ArrayAccess
      *
      * @return $this
      */
-    public function setDuration($duration)
+    public function setDuration($duration): static
     {
         $this->container['duration'] = $duration;
 
@@ -340,7 +338,7 @@ class Flightadditionaldetails implements ArrayAccess
     /**
      * Gets passengers.
      *
-     * @return \zipMoney\Model\FlightadditionaldetailsPassengers[]
+     * @return FlightadditionaldetailsPassengers[]
      */
     public function getPassengers()
     {
@@ -350,11 +348,11 @@ class Flightadditionaldetails implements ArrayAccess
     /**
      * Sets passengers.
      *
-     * @param \zipMoney\Model\FlightadditionaldetailsPassengers[] $passengers
+     * @param FlightadditionaldetailsPassengers[] $passengers
      *
      * @return $this
      */
-    public function setPassengers($passengers)
+    public function setPassengers($passengers): static
     {
         $this->container['passengers'] = $passengers;
 
@@ -378,7 +376,7 @@ class Flightadditionaldetails implements ArrayAccess
      *
      * @return $this
      */
-    public function setStopovers($stopovers)
+    public function setStopovers($stopovers): static
     {
         $this->container['stopovers'] = $stopovers;
 
@@ -389,8 +387,6 @@ class Flightadditionaldetails implements ArrayAccess
      * Returns true if offset exists. False otherwise.
      *
      * @param int $offset Offset
-     *
-     * @return bool
      */
     public function offsetExists($offset): bool
     {
@@ -401,8 +397,6 @@ class Flightadditionaldetails implements ArrayAccess
      * Gets offset.
      *
      * @param int $offset Offset
-     *
-     * @return mixed
      */
     public function offsetGet($offset): mixed
     {
@@ -415,7 +409,7 @@ class Flightadditionaldetails implements ArrayAccess
      * @param int   $offset Offset
      * @param mixed $value  Value to be set
      */
-    public function offsetSet($offset, $value): void
+    public function offsetSet($offset, mixed $value): void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -436,15 +430,13 @@ class Flightadditionaldetails implements ArrayAccess
 
     /**
      * Gets the string presentation of the object.
-     *
-     * @return string
      */
-    public function __toString()
+    public function __toString(): string
     {
         if (defined('JSON_PRETTY_PRINT')) { // use JSON pretty print
-            return json_encode(\zipMoney\ObjectSerializer::sanitizeForSerialization($this), JSON_PRETTY_PRINT);
+            return (string) json_encode(ObjectSerializer::sanitizeForSerialization($this), JSON_PRETTY_PRINT);
         }
 
-        return json_encode(\zipMoney\ObjectSerializer::sanitizeForSerialization($this));
+        return (string) json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }

--- a/lib/Model/FlightadditionaldetailsPassengers.php
+++ b/lib/Model/FlightadditionaldetailsPassengers.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 /**
@@ -13,8 +14,9 @@ declare(strict_types=1);
 namespace zipMoney\Model;
 
 use ArrayAccess;
+use zipMoney\ObjectSerializer;
 
-class FlightadditionaldetailsPassengers implements ArrayAccess
+class FlightadditionaldetailsPassengers implements ArrayAccess, \Stringable
 {
     public const DISCRIMINATOR = 'subclass';
 
@@ -115,12 +117,12 @@ class FlightadditionaldetailsPassengers implements ArrayAccess
      */
     public function __construct(?array $data = null)
     {
-        $this->container['title'] = isset($data['title']) ? $data['title'] : null;
-        $this->container['first_name'] = isset($data['first_name']) ? $data['first_name'] : null;
-        $this->container['last_name'] = isset($data['last_name']) ? $data['last_name'] : null;
-        $this->container['gender'] = isset($data['gender']) ? $data['gender'] : null;
-        $this->container['date_of_birth'] = isset($data['date_of_birth']) ? $data['date_of_birth'] : null;
-        $this->container['seat_number'] = isset($data['seat_number']) ? $data['seat_number'] : null;
+        $this->container['title'] = $data['title'] ?? null;
+        $this->container['first_name'] = $data['first_name'] ?? null;
+        $this->container['last_name'] = $data['last_name'] ?? null;
+        $this->container['gender'] = $data['gender'] ?? null;
+        $this->container['date_of_birth'] = $data['date_of_birth'] ?? null;
+        $this->container['seat_number'] = $data['seat_number'] ?? null;
     }
 
     /**
@@ -128,7 +130,7 @@ class FlightadditionaldetailsPassengers implements ArrayAccess
      *
      * @return array invalid properties with reasons
      */
-    public function listInvalidProperties()
+    public function listInvalidProperties(): array
     {
         $invalid_properties = [];
 
@@ -153,11 +155,7 @@ class FlightadditionaldetailsPassengers implements ArrayAccess
         if ($this->container['first_name'] === null) {
             return false;
         }
-        if ($this->container['last_name'] === null) {
-            return false;
-        }
-
-        return true;
+        return $this->container['last_name'] !== null;
     }
 
     /**
@@ -177,7 +175,7 @@ class FlightadditionaldetailsPassengers implements ArrayAccess
      *
      * @return $this
      */
-    public function setTitle($title)
+    public function setTitle($title): static
     {
         $this->container['title'] = $title;
 
@@ -201,7 +199,7 @@ class FlightadditionaldetailsPassengers implements ArrayAccess
      *
      * @return $this
      */
-    public function setFirstName($first_name)
+    public function setFirstName($first_name): static
     {
         $this->container['first_name'] = $first_name;
 
@@ -225,7 +223,7 @@ class FlightadditionaldetailsPassengers implements ArrayAccess
      *
      * @return $this
      */
-    public function setLastName($last_name)
+    public function setLastName($last_name): static
     {
         $this->container['last_name'] = $last_name;
 
@@ -249,7 +247,7 @@ class FlightadditionaldetailsPassengers implements ArrayAccess
      *
      * @return $this
      */
-    public function setGender($gender)
+    public function setGender($gender): static
     {
         $this->container['gender'] = $gender;
 
@@ -273,7 +271,7 @@ class FlightadditionaldetailsPassengers implements ArrayAccess
      *
      * @return $this
      */
-    public function setDateOfBirth($date_of_birth)
+    public function setDateOfBirth($date_of_birth): static
     {
         $this->container['date_of_birth'] = $date_of_birth;
 
@@ -297,7 +295,7 @@ class FlightadditionaldetailsPassengers implements ArrayAccess
      *
      * @return $this
      */
-    public function setSeatNumber($seat_number)
+    public function setSeatNumber($seat_number): static
     {
         $this->container['seat_number'] = $seat_number;
 
@@ -308,8 +306,6 @@ class FlightadditionaldetailsPassengers implements ArrayAccess
      * Returns true if offset exists. False otherwise.
      *
      * @param int $offset Offset
-     *
-     * @return bool
      */
     public function offsetExists($offset): bool
     {
@@ -320,8 +316,6 @@ class FlightadditionaldetailsPassengers implements ArrayAccess
      * Gets offset.
      *
      * @param int $offset Offset
-     *
-     * @return mixed
      */
     public function offsetGet($offset): mixed
     {
@@ -334,7 +328,7 @@ class FlightadditionaldetailsPassengers implements ArrayAccess
      * @param int   $offset Offset
      * @param mixed $value  Value to be set
      */
-    public function offsetSet($offset, $value): void
+    public function offsetSet($offset, mixed $value): void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -355,15 +349,13 @@ class FlightadditionaldetailsPassengers implements ArrayAccess
 
     /**
      * Gets the string presentation of the object.
-     *
-     * @return string
      */
-    public function __toString()
+    public function __toString(): string
     {
         if (defined('JSON_PRETTY_PRINT')) { // use JSON pretty print
-            return json_encode(\zipMoney\ObjectSerializer::sanitizeForSerialization($this), JSON_PRETTY_PRINT);
+            return (string) json_encode(ObjectSerializer::sanitizeForSerialization($this), JSON_PRETTY_PRINT);
         }
 
-        return json_encode(\zipMoney\ObjectSerializer::sanitizeForSerialization($this));
+        return (string) json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }

--- a/lib/Model/HateoasLinks.php
+++ b/lib/Model/HateoasLinks.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 /**
@@ -13,8 +14,9 @@ declare(strict_types=1);
 namespace zipMoney\Model;
 
 use ArrayAccess;
+use zipMoney\ObjectSerializer;
 
-class HateoasLinks implements ArrayAccess
+class HateoasLinks implements ArrayAccess, \Stringable
 {
     public const DISCRIMINATOR = 'subclass';
 
@@ -95,7 +97,7 @@ class HateoasLinks implements ArrayAccess
      */
     public function __construct(?array $data = null)
     {
-        $this->container['_links'] = isset($data['_links']) ? $data['_links'] : null;
+        $this->container['_links'] = $data['_links'] ?? null;
     }
 
     /**
@@ -103,7 +105,7 @@ class HateoasLinks implements ArrayAccess
      *
      * @return array invalid properties with reasons
      */
-    public function listInvalidProperties()
+    public function listInvalidProperties(): array
     {
         return [];
     }
@@ -114,7 +116,7 @@ class HateoasLinks implements ArrayAccess
      *
      * @return bool True if all properties are valid
      */
-    public function valid()
+    public function valid(): bool
     {
         return true;
     }
@@ -122,7 +124,7 @@ class HateoasLinks implements ArrayAccess
     /**
      * Gets _links.
      *
-     * @return \zipMoney\Model\HateoaslinksLinks[]
+     * @return HateoaslinksLinks[]
      */
     public function getLinks()
     {
@@ -132,11 +134,11 @@ class HateoasLinks implements ArrayAccess
     /**
      * Sets _links.
      *
-     * @param \zipMoney\Model\HateoaslinksLinks[] $_links
+     * @param HateoaslinksLinks[] $_links
      *
      * @return $this
      */
-    public function setLinks($_links)
+    public function setLinks($_links): static
     {
         $this->container['_links'] = $_links;
 
@@ -147,8 +149,6 @@ class HateoasLinks implements ArrayAccess
      * Returns true if offset exists. False otherwise.
      *
      * @param int $offset Offset
-     *
-     * @return bool
      */
     public function offsetExists($offset): bool
     {
@@ -159,8 +159,6 @@ class HateoasLinks implements ArrayAccess
      * Gets offset.
      *
      * @param int $offset Offset
-     *
-     * @return mixed
      */
     public function offsetGet($offset): mixed
     {
@@ -173,7 +171,7 @@ class HateoasLinks implements ArrayAccess
      * @param int   $offset Offset
      * @param mixed $value  Value to be set
      */
-    public function offsetSet($offset, $value): void
+    public function offsetSet($offset, mixed $value): void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -194,15 +192,13 @@ class HateoasLinks implements ArrayAccess
 
     /**
      * Gets the string presentation of the object.
-     *
-     * @return string
      */
-    public function __toString()
+    public function __toString(): string
     {
         if (defined('JSON_PRETTY_PRINT')) { // use JSON pretty print
-            return json_encode(\zipMoney\ObjectSerializer::sanitizeForSerialization($this), JSON_PRETTY_PRINT);
+            return (string) json_encode(ObjectSerializer::sanitizeForSerialization($this), JSON_PRETTY_PRINT);
         }
 
-        return json_encode(\zipMoney\ObjectSerializer::sanitizeForSerialization($this));
+        return (string) json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }

--- a/lib/Model/HateoaslinksLinks.php
+++ b/lib/Model/HateoaslinksLinks.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 /**
@@ -13,8 +14,9 @@ declare(strict_types=1);
 namespace zipMoney\Model;
 
 use ArrayAccess;
+use zipMoney\ObjectSerializer;
 
-class HateoaslinksLinks implements ArrayAccess
+class HateoaslinksLinks implements ArrayAccess, \Stringable
 {
     public const DISCRIMINATOR = 'subclass';
 
@@ -103,9 +105,9 @@ class HateoaslinksLinks implements ArrayAccess
      */
     public function __construct(?array $data = null)
     {
-        $this->container['href'] = isset($data['href']) ? $data['href'] : null;
-        $this->container['rel'] = isset($data['rel']) ? $data['rel'] : null;
-        $this->container['method'] = isset($data['method']) ? $data['method'] : null;
+        $this->container['href'] = $data['href'] ?? null;
+        $this->container['rel'] = $data['rel'] ?? null;
+        $this->container['method'] = $data['method'] ?? null;
     }
 
     /**
@@ -113,7 +115,7 @@ class HateoaslinksLinks implements ArrayAccess
      *
      * @return array invalid properties with reasons
      */
-    public function listInvalidProperties()
+    public function listInvalidProperties(): array
     {
         return [];
     }
@@ -124,7 +126,7 @@ class HateoaslinksLinks implements ArrayAccess
      *
      * @return bool True if all properties are valid
      */
-    public function valid()
+    public function valid(): bool
     {
         return true;
     }
@@ -146,7 +148,7 @@ class HateoaslinksLinks implements ArrayAccess
      *
      * @return $this
      */
-    public function setHref($href)
+    public function setHref($href): static
     {
         $this->container['href'] = $href;
 
@@ -170,7 +172,7 @@ class HateoaslinksLinks implements ArrayAccess
      *
      * @return $this
      */
-    public function setRel($rel)
+    public function setRel($rel): static
     {
         $this->container['rel'] = $rel;
 
@@ -194,7 +196,7 @@ class HateoaslinksLinks implements ArrayAccess
      *
      * @return $this
      */
-    public function setMethod($method)
+    public function setMethod($method): static
     {
         $this->container['method'] = $method;
 
@@ -205,8 +207,6 @@ class HateoaslinksLinks implements ArrayAccess
      * Returns true if offset exists. False otherwise.
      *
      * @param int $offset Offset
-     *
-     * @return bool
      */
     public function offsetExists($offset): bool
     {
@@ -217,8 +217,6 @@ class HateoaslinksLinks implements ArrayAccess
      * Gets offset.
      *
      * @param int $offset Offset
-     *
-     * @return mixed
      */
     public function offsetGet($offset): mixed
     {
@@ -231,7 +229,7 @@ class HateoaslinksLinks implements ArrayAccess
      * @param int   $offset Offset
      * @param mixed $value  Value to be set
      */
-    public function offsetSet($offset, $value): void
+    public function offsetSet($offset, mixed $value): void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -252,15 +250,13 @@ class HateoaslinksLinks implements ArrayAccess
 
     /**
      * Gets the string presentation of the object.
-     *
-     * @return string
      */
-    public function __toString()
+    public function __toString(): string
     {
         if (defined('JSON_PRETTY_PRINT')) { // use JSON pretty print
-            return json_encode(\zipMoney\ObjectSerializer::sanitizeForSerialization($this), JSON_PRETTY_PRINT);
+            return (string) json_encode(ObjectSerializer::sanitizeForSerialization($this), JSON_PRETTY_PRINT);
         }
 
-        return json_encode(\zipMoney\ObjectSerializer::sanitizeForSerialization($this));
+        return (string) json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }

--- a/lib/Model/InlineResponse200.php
+++ b/lib/Model/InlineResponse200.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 /**
@@ -13,8 +14,9 @@ declare(strict_types=1);
 namespace zipMoney\Model;
 
 use ArrayAccess;
+use zipMoney\ObjectSerializer;
 
-class InlineResponse200 implements ArrayAccess
+class InlineResponse200 implements ArrayAccess, \Stringable
 {
     public const DISCRIMINATOR = 'subclass';
 
@@ -95,7 +97,7 @@ class InlineResponse200 implements ArrayAccess
      */
     public function __construct(?array $data = null)
     {
-        $this->container['items'] = isset($data['items']) ? $data['items'] : null;
+        $this->container['items'] = $data['items'] ?? null;
     }
 
     /**
@@ -103,7 +105,7 @@ class InlineResponse200 implements ArrayAccess
      *
      * @return array invalid properties with reasons
      */
-    public function listInvalidProperties()
+    public function listInvalidProperties(): array
     {
         $invalid_properties = [];
 
@@ -120,19 +122,15 @@ class InlineResponse200 implements ArrayAccess
      *
      * @return bool True if all properties are valid
      */
-    public function valid()
+    public function valid(): bool
     {
-        if ($this->container['items'] === null) {
-            return false;
-        }
-
-        return true;
+        return $this->container['items'] !== null;
     }
 
     /**
      * Gets items.
      *
-     * @return \zipMoney\Model\Refund[]
+     * @return Refund[]
      */
     public function getItems()
     {
@@ -142,11 +140,11 @@ class InlineResponse200 implements ArrayAccess
     /**
      * Sets items.
      *
-     * @param \zipMoney\Model\Refund[] $items
+     * @param Refund[] $items
      *
      * @return $this
      */
-    public function setItems($items)
+    public function setItems($items): static
     {
         $this->container['items'] = $items;
 
@@ -157,8 +155,6 @@ class InlineResponse200 implements ArrayAccess
      * Returns true if offset exists. False otherwise.
      *
      * @param int $offset Offset
-     *
-     * @return bool
      */
     public function offsetExists($offset): bool
     {
@@ -169,8 +165,6 @@ class InlineResponse200 implements ArrayAccess
      * Gets offset.
      *
      * @param int $offset Offset
-     *
-     * @return mixed
      */
     public function offsetGet($offset): mixed
     {
@@ -183,7 +177,7 @@ class InlineResponse200 implements ArrayAccess
      * @param int   $offset Offset
      * @param mixed $value  Value to be set
      */
-    public function offsetSet($offset, $value): void
+    public function offsetSet($offset, mixed $value): void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -204,15 +198,13 @@ class InlineResponse200 implements ArrayAccess
 
     /**
      * Gets the string presentation of the object.
-     *
-     * @return string
      */
-    public function __toString()
+    public function __toString(): string
     {
         if (defined('JSON_PRETTY_PRINT')) { // use JSON pretty print
-            return json_encode(\zipMoney\ObjectSerializer::sanitizeForSerialization($this), JSON_PRETTY_PRINT);
+            return (string) json_encode(ObjectSerializer::sanitizeForSerialization($this), JSON_PRETTY_PRINT);
         }
 
-        return json_encode(\zipMoney\ObjectSerializer::sanitizeForSerialization($this));
+        return (string) json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }

--- a/lib/Model/Metadata.php
+++ b/lib/Model/Metadata.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 /**
@@ -13,8 +14,9 @@ declare(strict_types=1);
 namespace zipMoney\Model;
 
 use ArrayAccess;
+use zipMoney\ObjectSerializer;
 
-class Metadata implements ArrayAccess
+class Metadata implements ArrayAccess, \Stringable
 {
     public const DISCRIMINATOR = 'subclass';
 
@@ -101,7 +103,7 @@ class Metadata implements ArrayAccess
      *
      * @return array invalid properties with reasons
      */
-    public function listInvalidProperties()
+    public function listInvalidProperties(): array
     {
         return [];
     }
@@ -112,7 +114,7 @@ class Metadata implements ArrayAccess
      *
      * @return bool True if all properties are valid
      */
-    public function valid()
+    public function valid(): bool
     {
         return true;
     }
@@ -121,8 +123,6 @@ class Metadata implements ArrayAccess
      * Returns true if offset exists. False otherwise.
      *
      * @param int $offset Offset
-     *
-     * @return bool
      */
     public function offsetExists($offset): bool
     {
@@ -133,8 +133,6 @@ class Metadata implements ArrayAccess
      * Gets offset.
      *
      * @param int $offset Offset
-     *
-     * @return mixed
      */
     public function offsetGet($offset): mixed
     {
@@ -147,7 +145,7 @@ class Metadata implements ArrayAccess
      * @param int   $offset Offset
      * @param mixed $value  Value to be set
      */
-    public function offsetSet($offset, $value): void
+    public function offsetSet($offset, mixed $value): void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -166,7 +164,7 @@ class Metadata implements ArrayAccess
         unset($this->container[$offset]);
     }
 
-    public function set($array)
+    public function set($array): void
     {
         foreach ($array as $key => $value) {
             if (!property_exists($this, $key)) {
@@ -175,7 +173,7 @@ class Metadata implements ArrayAccess
         }
     }
 
-    public function setData($key, $value)
+    public function setData($key, $value): void
     {
         $this->container[$key] = $value;
         $propertyName = str_replace('_', '', ucwords($key, '_'));
@@ -187,26 +185,23 @@ class Metadata implements ArrayAccess
     /**
      * Gets.
      *
-     * @param mixed $key
      *
      * @return string
      */
-    public function get($key)
+    public function get(mixed $key)
     {
         return $this->container[$key];
     }
 
     /**
      * Gets the string presentation of the object.
-     *
-     * @return string
      */
-    public function __toString()
+    public function __toString(): string
     {
         if (defined('JSON_PRETTY_PRINT')) { // use JSON pretty print
-            return json_encode(\zipMoney\ObjectSerializer::sanitizeForSerialization($this), JSON_PRETTY_PRINT);
+            return (string) json_encode(ObjectSerializer::sanitizeForSerialization($this), JSON_PRETTY_PRINT);
         }
 
-        return json_encode(\zipMoney\ObjectSerializer::sanitizeForSerialization($this));
+        return (string) json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }

--- a/lib/Model/OrderItem.php
+++ b/lib/Model/OrderItem.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 /**
@@ -13,8 +14,9 @@ declare(strict_types=1);
 namespace zipMoney\Model;
 
 use ArrayAccess;
+use zipMoney\ObjectSerializer;
 
-class OrderItem implements ArrayAccess
+class OrderItem implements ArrayAccess, \Stringable
 {
     public const DISCRIMINATOR = 'subclass';
 
@@ -128,7 +130,7 @@ class OrderItem implements ArrayAccess
      *
      * @return string[]
      */
-    public function getTypeAllowableValues()
+    public function getTypeAllowableValues(): array
     {
         return [
             self::TYPE_SKU,
@@ -153,16 +155,16 @@ class OrderItem implements ArrayAccess
      */
     public function __construct(?array $data = null)
     {
-        $this->container['name'] = isset($data['name']) ? $data['name'] : null;
-        $this->container['amount'] = isset($data['amount']) ? $data['amount'] : null;
-        $this->container['reference'] = isset($data['reference']) ? $data['reference'] : null;
-        $this->container['description'] = isset($data['description']) ? $data['description'] : null;
-        $this->container['quantity'] = isset($data['quantity']) ? $data['quantity'] : null;
-        $this->container['type'] = isset($data['type']) ? $data['type'] : null;
-        $this->container['image_uri'] = isset($data['image_uri']) ? $data['image_uri'] : null;
-        $this->container['item_uri'] = isset($data['item_uri']) ? $data['item_uri'] : null;
-        $this->container['product_code'] = isset($data['product_code']) ? $data['product_code'] : null;
-        $this->container['additional_details'] = isset($data['additional_details']) ? $data['additional_details'] : null;
+        $this->container['name'] = $data['name'] ?? null;
+        $this->container['amount'] = $data['amount'] ?? null;
+        $this->container['reference'] = $data['reference'] ?? null;
+        $this->container['description'] = $data['description'] ?? null;
+        $this->container['quantity'] = $data['quantity'] ?? null;
+        $this->container['type'] = $data['type'] ?? null;
+        $this->container['image_uri'] = $data['image_uri'] ?? null;
+        $this->container['item_uri'] = $data['item_uri'] ?? null;
+        $this->container['product_code'] = $data['product_code'] ?? null;
+        $this->container['additional_details'] = $data['additional_details'] ?? null;
     }
 
     /**
@@ -170,7 +172,7 @@ class OrderItem implements ArrayAccess
      *
      * @return array invalid properties with reasons
      */
-    public function listInvalidProperties()
+    public function listInvalidProperties(): array
     {
         $invalid_properties = [];
 
@@ -223,11 +225,7 @@ class OrderItem implements ArrayAccess
         if (!in_array($this->container['type'], $allowed_values)) {
             return false;
         }
-        if (strlen($this->container['product_code']) > 200) {
-            return false;
-        }
-
-        return true;
+        return strlen($this->container['product_code']) <= 200;
     }
 
     /**
@@ -247,7 +245,7 @@ class OrderItem implements ArrayAccess
      *
      * @return $this
      */
-    public function setName($name)
+    public function setName($name): static
     {
         $this->container['name'] = $name;
 
@@ -271,7 +269,7 @@ class OrderItem implements ArrayAccess
      *
      * @return $this
      */
-    public function setAmount($amount)
+    public function setAmount($amount): static
     {
         $this->container['amount'] = $amount;
 
@@ -295,7 +293,7 @@ class OrderItem implements ArrayAccess
      *
      * @return $this
      */
-    public function setReference($reference)
+    public function setReference($reference): static
     {
         $this->container['reference'] = $reference;
 
@@ -319,7 +317,7 @@ class OrderItem implements ArrayAccess
      *
      * @return $this
      */
-    public function setDescription($description)
+    public function setDescription($description): static
     {
         $this->container['description'] = $description;
 
@@ -343,7 +341,7 @@ class OrderItem implements ArrayAccess
      *
      * @return $this
      */
-    public function setQuantity($quantity)
+    public function setQuantity($quantity): static
     {
         if (!is_null($quantity) && ($quantity <= 0)) {
             throw new \InvalidArgumentException('invalid value for $quantity when calling OrderItem., must be bigger than 0.');
@@ -371,7 +369,7 @@ class OrderItem implements ArrayAccess
      *
      * @return $this
      */
-    public function setType($type)
+    public function setType($type): static
     {
         $allowed_values = ['sku', 'tax', 'shipping', 'discount', 'store_credit'];
         if ((!in_array($type, $allowed_values))) {
@@ -399,7 +397,7 @@ class OrderItem implements ArrayAccess
      *
      * @return $this
      */
-    public function setImageUri($image_uri)
+    public function setImageUri($image_uri): static
     {
         $this->container['image_uri'] = $image_uri;
 
@@ -423,7 +421,7 @@ class OrderItem implements ArrayAccess
      *
      * @return $this
      */
-    public function setItemUri($item_uri)
+    public function setItemUri($item_uri): static
     {
         $this->container['item_uri'] = $item_uri;
 
@@ -447,7 +445,7 @@ class OrderItem implements ArrayAccess
      *
      * @return $this
      */
-    public function setProductCode($product_code)
+    public function setProductCode($product_code): static
     {
         if (!is_null($product_code) && (strlen($product_code) > 200)) {
             throw new \InvalidArgumentException('invalid length for $product_code when calling OrderItem., must be smaller than or equal to 200.');
@@ -461,7 +459,7 @@ class OrderItem implements ArrayAccess
     /**
      * Gets additional_details.
      *
-     * @return \zipMoney\Model\OrderItemAdditionalDetails[]
+     * @return OrderItemAdditionalDetails[]
      */
     public function getAdditionalDetails()
     {
@@ -471,11 +469,11 @@ class OrderItem implements ArrayAccess
     /**
      * Sets additional_details.
      *
-     * @param \zipMoney\Model\OrderItemAdditionalDetails[] $additional_details
+     * @param OrderItemAdditionalDetails[] $additional_details
      *
      * @return $this
      */
-    public function setAdditionalDetails($additional_details)
+    public function setAdditionalDetails($additional_details): static
     {
         $this->container['additional_details'] = $additional_details;
 
@@ -486,8 +484,6 @@ class OrderItem implements ArrayAccess
      * Returns true if offset exists. False otherwise.
      *
      * @param int $offset Offset
-     *
-     * @return bool
      */
     public function offsetExists($offset): bool
     {
@@ -498,8 +494,6 @@ class OrderItem implements ArrayAccess
      * Gets offset.
      *
      * @param int $offset Offset
-     *
-     * @return mixed
      */
     public function offsetGet($offset): mixed
     {
@@ -512,7 +506,7 @@ class OrderItem implements ArrayAccess
      * @param int   $offset Offset
      * @param mixed $value  Value to be set
      */
-    public function offsetSet($offset, $value): void
+    public function offsetSet($offset, mixed $value): void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -533,15 +527,13 @@ class OrderItem implements ArrayAccess
 
     /**
      * Gets the string presentation of the object.
-     *
-     * @return string
      */
-    public function __toString()
+    public function __toString(): string
     {
         if (defined('JSON_PRETTY_PRINT')) { // use JSON pretty print
-            return json_encode(\zipMoney\ObjectSerializer::sanitizeForSerialization($this), JSON_PRETTY_PRINT);
+            return (string) json_encode(ObjectSerializer::sanitizeForSerialization($this), JSON_PRETTY_PRINT);
         }
 
-        return json_encode(\zipMoney\ObjectSerializer::sanitizeForSerialization($this));
+        return (string) json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }

--- a/lib/Model/OrderItemAdditionalDetails.php
+++ b/lib/Model/OrderItemAdditionalDetails.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 /**
@@ -13,8 +14,9 @@ declare(strict_types=1);
 namespace zipMoney\Model;
 
 use ArrayAccess;
+use zipMoney\ObjectSerializer;
 
-class OrderItemAdditionalDetails implements ArrayAccess
+class OrderItemAdditionalDetails implements ArrayAccess, \Stringable
 {
     public const DISCRIMINATOR = 'subclass';
 
@@ -88,7 +90,7 @@ class OrderItemAdditionalDetails implements ArrayAccess
      *
      * @return string[]
      */
-    public function getTypeAllowableValues()
+    public function getTypeAllowableValues(): array
     {
         return [
             self::TYPE_FLIGHTS,
@@ -109,7 +111,7 @@ class OrderItemAdditionalDetails implements ArrayAccess
      */
     public function __construct(?array $data = null)
     {
-        $this->container['type'] = isset($data['type']) ? $data['type'] : null;
+        $this->container['type'] = $data['type'] ?? null;
     }
 
     /**
@@ -117,7 +119,7 @@ class OrderItemAdditionalDetails implements ArrayAccess
      *
      * @return array invalid properties with reasons
      */
-    public function listInvalidProperties()
+    public function listInvalidProperties(): array
     {
         $invalid_properties = [];
 
@@ -135,14 +137,10 @@ class OrderItemAdditionalDetails implements ArrayAccess
      *
      * @return bool True if all properties are valid
      */
-    public function valid()
+    public function valid(): bool
     {
         $allowed_values = ['Flights'];
-        if (!in_array($this->container['type'], $allowed_values)) {
-            return false;
-        }
-
-        return true;
+        return in_array($this->container['type'], $allowed_values);
     }
 
     /**
@@ -162,7 +160,7 @@ class OrderItemAdditionalDetails implements ArrayAccess
      *
      * @return $this
      */
-    public function setType($type)
+    public function setType($type): static
     {
         $allowed_values = ['Flights'];
         if (!is_null($type) && (!in_array($type, $allowed_values))) {
@@ -177,8 +175,6 @@ class OrderItemAdditionalDetails implements ArrayAccess
      * Returns true if offset exists. False otherwise.
      *
      * @param int $offset Offset
-     *
-     * @return bool
      */
     public function offsetExists($offset): bool
     {
@@ -189,8 +185,6 @@ class OrderItemAdditionalDetails implements ArrayAccess
      * Gets offset.
      *
      * @param int $offset Offset
-     *
-     * @return mixed
      */
     public function offsetGet($offset): mixed
     {
@@ -203,7 +197,7 @@ class OrderItemAdditionalDetails implements ArrayAccess
      * @param int   $offset Offset
      * @param mixed $value  Value to be set
      */
-    public function offsetSet($offset, $value): void
+    public function offsetSet($offset, mixed $value): void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -224,15 +218,13 @@ class OrderItemAdditionalDetails implements ArrayAccess
 
     /**
      * Gets the string presentation of the object.
-     *
-     * @return string
      */
-    public function __toString()
+    public function __toString(): string
     {
         if (defined('JSON_PRETTY_PRINT')) { // use JSON pretty print
-            return json_encode(\zipMoney\ObjectSerializer::sanitizeForSerialization($this), JSON_PRETTY_PRINT);
+            return (string) json_encode(ObjectSerializer::sanitizeForSerialization($this), JSON_PRETTY_PRINT);
         }
 
-        return json_encode(\zipMoney\ObjectSerializer::sanitizeForSerialization($this));
+        return (string) json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }

--- a/lib/Model/OrderShipping.php
+++ b/lib/Model/OrderShipping.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 /**
@@ -13,8 +14,9 @@ declare(strict_types=1);
 namespace zipMoney\Model;
 
 use ArrayAccess;
+use zipMoney\ObjectSerializer;
 
-class OrderShipping implements ArrayAccess
+class OrderShipping implements ArrayAccess, \Stringable
 {
     public const DISCRIMINATOR = 'subclass';
 
@@ -103,9 +105,9 @@ class OrderShipping implements ArrayAccess
      */
     public function __construct(?array $data = null)
     {
-        $this->container['pickup'] = isset($data['pickup']) ? $data['pickup'] : null;
-        $this->container['tracking'] = isset($data['tracking']) ? $data['tracking'] : null;
-        $this->container['address'] = isset($data['address']) ? $data['address'] : null;
+        $this->container['pickup'] = $data['pickup'] ?? null;
+        $this->container['tracking'] = $data['tracking'] ?? null;
+        $this->container['address'] = $data['address'] ?? null;
     }
 
     /**
@@ -113,7 +115,7 @@ class OrderShipping implements ArrayAccess
      *
      * @return array invalid properties with reasons
      */
-    public function listInvalidProperties()
+    public function listInvalidProperties(): array
     {
         return [];
     }
@@ -124,7 +126,7 @@ class OrderShipping implements ArrayAccess
      *
      * @return bool True if all properties are valid
      */
-    public function valid()
+    public function valid(): bool
     {
         return true;
     }
@@ -146,7 +148,7 @@ class OrderShipping implements ArrayAccess
      *
      * @return $this
      */
-    public function setPickup($pickup)
+    public function setPickup($pickup): static
     {
         $this->container['pickup'] = $pickup;
 
@@ -156,7 +158,7 @@ class OrderShipping implements ArrayAccess
     /**
      * Gets tracking.
      *
-     * @return \zipMoney\Model\OrderShippingTracking
+     * @return OrderShippingTracking
      */
     public function getTracking()
     {
@@ -166,11 +168,11 @@ class OrderShipping implements ArrayAccess
     /**
      * Sets tracking.
      *
-     * @param \zipMoney\Model\OrderShippingTracking $tracking
+     * @param OrderShippingTracking $tracking
      *
      * @return $this
      */
-    public function setTracking($tracking)
+    public function setTracking($tracking): static
     {
         $this->container['tracking'] = $tracking;
 
@@ -180,7 +182,7 @@ class OrderShipping implements ArrayAccess
     /**
      * Gets address.
      *
-     * @return \zipMoney\Model\Address
+     * @return Address
      */
     public function getAddress()
     {
@@ -190,11 +192,11 @@ class OrderShipping implements ArrayAccess
     /**
      * Sets address.
      *
-     * @param \zipMoney\Model\Address $address
+     * @param Address $address
      *
      * @return $this
      */
-    public function setAddress($address)
+    public function setAddress($address): static
     {
         $this->container['address'] = $address;
 
@@ -205,8 +207,6 @@ class OrderShipping implements ArrayAccess
      * Returns true if offset exists. False otherwise.
      *
      * @param int $offset Offset
-     *
-     * @return bool
      */
     public function offsetExists($offset): bool
     {
@@ -217,8 +217,6 @@ class OrderShipping implements ArrayAccess
      * Gets offset.
      *
      * @param int $offset Offset
-     *
-     * @return mixed
      */
     public function offsetGet($offset): mixed
     {
@@ -231,7 +229,7 @@ class OrderShipping implements ArrayAccess
      * @param int   $offset Offset
      * @param mixed $value  Value to be set
      */
-    public function offsetSet($offset, $value): void
+    public function offsetSet($offset, mixed $value): void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -252,15 +250,13 @@ class OrderShipping implements ArrayAccess
 
     /**
      * Gets the string presentation of the object.
-     *
-     * @return string
      */
-    public function __toString()
+    public function __toString(): string
     {
         if (defined('JSON_PRETTY_PRINT')) { // use JSON pretty print
-            return json_encode(\zipMoney\ObjectSerializer::sanitizeForSerialization($this), JSON_PRETTY_PRINT);
+            return (string) json_encode(ObjectSerializer::sanitizeForSerialization($this), JSON_PRETTY_PRINT);
         }
 
-        return json_encode(\zipMoney\ObjectSerializer::sanitizeForSerialization($this));
+        return (string) json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }

--- a/lib/Model/OrderShippingTracking.php
+++ b/lib/Model/OrderShippingTracking.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 /**
@@ -13,8 +14,9 @@ declare(strict_types=1);
 namespace zipMoney\Model;
 
 use ArrayAccess;
+use zipMoney\ObjectSerializer;
 
-class OrderShippingTracking implements ArrayAccess
+class OrderShippingTracking implements ArrayAccess, \Stringable
 {
     public const DISCRIMINATOR = 'subclass';
 
@@ -103,9 +105,9 @@ class OrderShippingTracking implements ArrayAccess
      */
     public function __construct(?array $data = null)
     {
-        $this->container['uri'] = isset($data['uri']) ? $data['uri'] : null;
-        $this->container['number'] = isset($data['number']) ? $data['number'] : null;
-        $this->container['carrier'] = isset($data['carrier']) ? $data['carrier'] : null;
+        $this->container['uri'] = $data['uri'] ?? null;
+        $this->container['number'] = $data['number'] ?? null;
+        $this->container['carrier'] = $data['carrier'] ?? null;
     }
 
     /**
@@ -113,7 +115,7 @@ class OrderShippingTracking implements ArrayAccess
      *
      * @return array invalid properties with reasons
      */
-    public function listInvalidProperties()
+    public function listInvalidProperties(): array
     {
         $invalid_properties = [];
 
@@ -146,11 +148,7 @@ class OrderShippingTracking implements ArrayAccess
         if (strlen($this->container['number']) > 120) {
             return false;
         }
-        if (strlen($this->container['carrier']) > 120) {
-            return false;
-        }
-
-        return true;
+        return strlen($this->container['carrier']) <= 120;
     }
 
     /**
@@ -170,7 +168,7 @@ class OrderShippingTracking implements ArrayAccess
      *
      * @return $this
      */
-    public function setUri($uri)
+    public function setUri($uri): static
     {
         if (!is_null($uri) && (strlen($uri) > 500)) {
             throw new \InvalidArgumentException('invalid length for $uri when calling OrderShippingTracking., must be smaller than or equal to 500.');
@@ -198,7 +196,7 @@ class OrderShippingTracking implements ArrayAccess
      *
      * @return $this
      */
-    public function setNumber($number)
+    public function setNumber($number): static
     {
         if (!is_null($number) && (strlen($number) > 120)) {
             throw new \InvalidArgumentException('invalid length for $number when calling OrderShippingTracking., must be smaller than or equal to 120.');
@@ -226,7 +224,7 @@ class OrderShippingTracking implements ArrayAccess
      *
      * @return $this
      */
-    public function setCarrier($carrier)
+    public function setCarrier($carrier): static
     {
         if (!is_null($carrier) && (strlen($carrier) > 120)) {
             throw new \InvalidArgumentException('invalid length for $carrier when calling OrderShippingTracking., must be smaller than or equal to 120.');
@@ -241,8 +239,6 @@ class OrderShippingTracking implements ArrayAccess
      * Returns true if offset exists. False otherwise.
      *
      * @param int $offset Offset
-     *
-     * @return bool
      */
     public function offsetExists($offset): bool
     {
@@ -253,8 +249,6 @@ class OrderShippingTracking implements ArrayAccess
      * Gets offset.
      *
      * @param int $offset Offset
-     *
-     * @return mixed
      */
     public function offsetGet($offset): mixed
     {
@@ -267,7 +261,7 @@ class OrderShippingTracking implements ArrayAccess
      * @param int   $offset Offset
      * @param mixed $value  Value to be set
      */
-    public function offsetSet($offset, $value): void
+    public function offsetSet($offset, mixed $value): void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -288,15 +282,13 @@ class OrderShippingTracking implements ArrayAccess
 
     /**
      * Gets the string presentation of the object.
-     *
-     * @return string
      */
-    public function __toString()
+    public function __toString(): string
     {
         if (defined('JSON_PRETTY_PRINT')) { // use JSON pretty print
-            return json_encode(\zipMoney\ObjectSerializer::sanitizeForSerialization($this), JSON_PRETTY_PRINT);
+            return (string) json_encode(ObjectSerializer::sanitizeForSerialization($this), JSON_PRETTY_PRINT);
         }
 
-        return json_encode(\zipMoney\ObjectSerializer::sanitizeForSerialization($this));
+        return (string) json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }

--- a/lib/Model/Refund.php
+++ b/lib/Model/Refund.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 /**
@@ -13,8 +14,9 @@ declare(strict_types=1);
 namespace zipMoney\Model;
 
 use ArrayAccess;
+use zipMoney\ObjectSerializer;
 
-class Refund implements ArrayAccess
+class Refund implements ArrayAccess, \Stringable
 {
     public const DISCRIMINATOR = 'subclass';
 
@@ -115,12 +117,12 @@ class Refund implements ArrayAccess
      */
     public function __construct(?array $data = null)
     {
-        $this->container['id'] = isset($data['id']) ? $data['id'] : null;
-        $this->container['charge_id'] = isset($data['charge_id']) ? $data['charge_id'] : null;
-        $this->container['reason'] = isset($data['reason']) ? $data['reason'] : null;
-        $this->container['amount'] = isset($data['amount']) ? $data['amount'] : null;
-        $this->container['created'] = isset($data['created']) ? $data['created'] : null;
-        $this->container['metadata'] = isset($data['metadata']) ? $data['metadata'] : null;
+        $this->container['id'] = $data['id'] ?? null;
+        $this->container['charge_id'] = $data['charge_id'] ?? null;
+        $this->container['reason'] = $data['reason'] ?? null;
+        $this->container['amount'] = $data['amount'] ?? null;
+        $this->container['created'] = $data['created'] ?? null;
+        $this->container['metadata'] = $data['metadata'] ?? null;
     }
 
     /**
@@ -128,7 +130,7 @@ class Refund implements ArrayAccess
      *
      * @return array invalid properties with reasons
      */
-    public function listInvalidProperties()
+    public function listInvalidProperties(): array
     {
         $invalid_properties = [];
 
@@ -165,11 +167,7 @@ class Refund implements ArrayAccess
         if ($this->container['amount'] === null) {
             return false;
         }
-        if ($this->container['created'] === null) {
-            return false;
-        }
-
-        return true;
+        return $this->container['created'] !== null;
     }
 
     /**
@@ -189,7 +187,7 @@ class Refund implements ArrayAccess
      *
      * @return $this
      */
-    public function setId($id)
+    public function setId($id): static
     {
         $this->container['id'] = $id;
 
@@ -213,7 +211,7 @@ class Refund implements ArrayAccess
      *
      * @return $this
      */
-    public function setChargeId($charge_id)
+    public function setChargeId($charge_id): static
     {
         $this->container['charge_id'] = $charge_id;
 
@@ -237,7 +235,7 @@ class Refund implements ArrayAccess
      *
      * @return $this
      */
-    public function setReason($reason)
+    public function setReason($reason): static
     {
         $this->container['reason'] = $reason;
 
@@ -261,7 +259,7 @@ class Refund implements ArrayAccess
      *
      * @return $this
      */
-    public function setAmount($amount)
+    public function setAmount($amount): static
     {
         $this->container['amount'] = $amount;
 
@@ -285,7 +283,7 @@ class Refund implements ArrayAccess
      *
      * @return $this
      */
-    public function setCreated($created)
+    public function setCreated($created): static
     {
         $this->container['created'] = $created;
 
@@ -309,7 +307,7 @@ class Refund implements ArrayAccess
      *
      * @return $this
      */
-    public function setMetadata($metadata)
+    public function setMetadata($metadata): static
     {
         $this->container['metadata'] = $metadata;
 
@@ -320,8 +318,6 @@ class Refund implements ArrayAccess
      * Returns true if offset exists. False otherwise.
      *
      * @param int $offset Offset
-     *
-     * @return bool
      */
     public function offsetExists($offset): bool
     {
@@ -332,8 +328,6 @@ class Refund implements ArrayAccess
      * Gets offset.
      *
      * @param int $offset Offset
-     *
-     * @return mixed
      */
     public function offsetGet($offset): mixed
     {
@@ -346,7 +340,7 @@ class Refund implements ArrayAccess
      * @param int   $offset Offset
      * @param mixed $value  Value to be set
      */
-    public function offsetSet($offset, $value): void
+    public function offsetSet($offset, mixed $value): void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -367,15 +361,13 @@ class Refund implements ArrayAccess
 
     /**
      * Gets the string presentation of the object.
-     *
-     * @return string
      */
-    public function __toString()
+    public function __toString(): string
     {
         if (defined('JSON_PRETTY_PRINT')) { // use JSON pretty print
-            return json_encode(\zipMoney\ObjectSerializer::sanitizeForSerialization($this), JSON_PRETTY_PRINT);
+            return (string) json_encode(ObjectSerializer::sanitizeForSerialization($this), JSON_PRETTY_PRINT);
         }
 
-        return json_encode(\zipMoney\ObjectSerializer::sanitizeForSerialization($this));
+        return (string) json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }

--- a/lib/Model/Settlement.php
+++ b/lib/Model/Settlement.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 /**
@@ -13,8 +14,9 @@ declare(strict_types=1);
 namespace zipMoney\Model;
 
 use ArrayAccess;
+use zipMoney\ObjectSerializer;
 
-class Settlement implements ArrayAccess
+class Settlement implements ArrayAccess, \Stringable
 {
     public const DISCRIMINATOR = 'subclass';
 
@@ -111,11 +113,11 @@ class Settlement implements ArrayAccess
      */
     public function __construct(?array $data = null)
     {
-        $this->container['id'] = isset($data['id']) ? $data['id'] : null;
-        $this->container['created'] = isset($data['created']) ? $data['created'] : null;
-        $this->container['amount'] = isset($data['amount']) ? $data['amount'] : null;
-        $this->container['currency'] = isset($data['currency']) ? $data['currency'] : null;
-        $this->container['transactions'] = isset($data['transactions']) ? $data['transactions'] : null;
+        $this->container['id'] = $data['id'] ?? null;
+        $this->container['created'] = $data['created'] ?? null;
+        $this->container['amount'] = $data['amount'] ?? null;
+        $this->container['currency'] = $data['currency'] ?? null;
+        $this->container['transactions'] = $data['transactions'] ?? null;
     }
 
     /**
@@ -123,7 +125,7 @@ class Settlement implements ArrayAccess
      *
      * @return array invalid properties with reasons
      */
-    public function listInvalidProperties()
+    public function listInvalidProperties(): array
     {
         return [];
     }
@@ -134,7 +136,7 @@ class Settlement implements ArrayAccess
      *
      * @return bool True if all properties are valid
      */
-    public function valid()
+    public function valid(): bool
     {
         return true;
     }
@@ -156,7 +158,7 @@ class Settlement implements ArrayAccess
      *
      * @return $this
      */
-    public function setId($id)
+    public function setId($id): static
     {
         $this->container['id'] = $id;
 
@@ -180,7 +182,7 @@ class Settlement implements ArrayAccess
      *
      * @return $this
      */
-    public function setCreated($created)
+    public function setCreated($created): static
     {
         $this->container['created'] = $created;
 
@@ -204,7 +206,7 @@ class Settlement implements ArrayAccess
      *
      * @return $this
      */
-    public function setAmount($amount)
+    public function setAmount($amount): static
     {
         $this->container['amount'] = $amount;
 
@@ -228,7 +230,7 @@ class Settlement implements ArrayAccess
      *
      * @return $this
      */
-    public function setCurrency($currency)
+    public function setCurrency($currency): static
     {
         $this->container['currency'] = $currency;
 
@@ -238,7 +240,7 @@ class Settlement implements ArrayAccess
     /**
      * Gets transactions.
      *
-     * @return \zipMoney\Model\SettlementTransactions[]
+     * @return SettlementTransactions[]
      */
     public function getTransactions()
     {
@@ -248,11 +250,11 @@ class Settlement implements ArrayAccess
     /**
      * Sets transactions.
      *
-     * @param \zipMoney\Model\SettlementTransactions[] $transactions
+     * @param SettlementTransactions[] $transactions
      *
      * @return $this
      */
-    public function setTransactions($transactions)
+    public function setTransactions($transactions): static
     {
         $this->container['transactions'] = $transactions;
 
@@ -263,8 +265,6 @@ class Settlement implements ArrayAccess
      * Returns true if offset exists. False otherwise.
      *
      * @param int $offset Offset
-     *
-     * @return bool
      */
     public function offsetExists($offset): bool
     {
@@ -275,8 +275,6 @@ class Settlement implements ArrayAccess
      * Gets offset.
      *
      * @param int $offset Offset
-     *
-     * @return mixed
      */
     public function offsetGet($offset): mixed
     {
@@ -289,7 +287,7 @@ class Settlement implements ArrayAccess
      * @param int   $offset Offset
      * @param mixed $value  Value to be set
      */
-    public function offsetSet($offset, $value): void
+    public function offsetSet($offset, mixed $value): void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -310,15 +308,13 @@ class Settlement implements ArrayAccess
 
     /**
      * Gets the string presentation of the object.
-     *
-     * @return string
      */
-    public function __toString()
+    public function __toString(): string
     {
         if (defined('JSON_PRETTY_PRINT')) { // use JSON pretty print
-            return json_encode(\zipMoney\ObjectSerializer::sanitizeForSerialization($this), JSON_PRETTY_PRINT);
+            return (string) json_encode(ObjectSerializer::sanitizeForSerialization($this), JSON_PRETTY_PRINT);
         }
 
-        return json_encode(\zipMoney\ObjectSerializer::sanitizeForSerialization($this));
+        return (string) json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }

--- a/lib/Model/SettlementTransactions.php
+++ b/lib/Model/SettlementTransactions.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 /**
@@ -13,8 +14,9 @@ declare(strict_types=1);
 namespace zipMoney\Model;
 
 use ArrayAccess;
+use zipMoney\ObjectSerializer;
 
-class SettlementTransactions implements ArrayAccess
+class SettlementTransactions implements ArrayAccess, \Stringable
 {
     public const DISCRIMINATOR = 'subclass';
 
@@ -103,9 +105,9 @@ class SettlementTransactions implements ArrayAccess
      */
     public function __construct(?array $data = null)
     {
-        $this->container['id'] = isset($data['id']) ? $data['id'] : null;
-        $this->container['charge_id'] = isset($data['charge_id']) ? $data['charge_id'] : null;
-        $this->container[''] = isset($data['']) ? $data[''] : null;
+        $this->container['id'] = $data['id'] ?? null;
+        $this->container['charge_id'] = $data['charge_id'] ?? null;
+        $this->container[''] = $data[''] ?? null;
     }
 
     /**
@@ -113,7 +115,7 @@ class SettlementTransactions implements ArrayAccess
      *
      * @return array invalid properties with reasons
      */
-    public function listInvalidProperties()
+    public function listInvalidProperties(): array
     {
         return [];
     }
@@ -124,7 +126,7 @@ class SettlementTransactions implements ArrayAccess
      *
      * @return bool True if all properties are valid
      */
-    public function valid()
+    public function valid(): bool
     {
         return true;
     }
@@ -146,7 +148,7 @@ class SettlementTransactions implements ArrayAccess
      *
      * @return $this
      */
-    public function setId($id)
+    public function setId($id): static
     {
         $this->container['id'] = $id;
 
@@ -170,7 +172,7 @@ class SettlementTransactions implements ArrayAccess
      *
      * @return $this
      */
-    public function setChargeId($charge_id)
+    public function setChargeId($charge_id): static
     {
         $this->container['charge_id'] = $charge_id;
 
@@ -191,11 +193,10 @@ class SettlementTransactions implements ArrayAccess
      * Sets.
      *
      * @param string $
-     * @param mixed $val
      *
      * @return $this
      */
-    public function set($val)
+    public function set(mixed $val): static
     {
         $this->container[''] = $val;
 
@@ -206,8 +207,6 @@ class SettlementTransactions implements ArrayAccess
      * Returns true if offset exists. False otherwise.
      *
      * @param int $offset Offset
-     *
-     * @return bool
      */
     public function offsetExists($offset): bool
     {
@@ -218,8 +217,6 @@ class SettlementTransactions implements ArrayAccess
      * Gets offset.
      *
      * @param int $offset Offset
-     *
-     * @return mixed
      */
     public function offsetGet($offset): mixed
     {
@@ -232,7 +229,7 @@ class SettlementTransactions implements ArrayAccess
      * @param int   $offset Offset
      * @param mixed $value  Value to be set
      */
-    public function offsetSet($offset, $value): void
+    public function offsetSet($offset, mixed $value): void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -253,15 +250,13 @@ class SettlementTransactions implements ArrayAccess
 
     /**
      * Gets the string presentation of the object.
-     *
-     * @return string
      */
-    public function __toString()
+    public function __toString(): string
     {
         if (defined('JSON_PRETTY_PRINT')) { // use JSON pretty print
-            return json_encode(\zipMoney\ObjectSerializer::sanitizeForSerialization($this), JSON_PRETTY_PRINT);
+            return (string) json_encode(ObjectSerializer::sanitizeForSerialization($this), JSON_PRETTY_PRINT);
         }
 
-        return json_encode(\zipMoney\ObjectSerializer::sanitizeForSerialization($this));
+        return (string) json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }

--- a/lib/Model/Shopper.php
+++ b/lib/Model/Shopper.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 /**
@@ -13,8 +14,9 @@ declare(strict_types=1);
 namespace zipMoney\Model;
 
 use ArrayAccess;
+use zipMoney\ObjectSerializer;
 
-class Shopper implements ArrayAccess
+class Shopper implements ArrayAccess, \Stringable
 {
     public const DISCRIMINATOR = 'subclass';
 
@@ -126,7 +128,7 @@ class Shopper implements ArrayAccess
      *
      * @return string[]
      */
-    public function getGenderAllowableValues()
+    public function getGenderAllowableValues(): array
     {
         return [
             self::GENDER_MALE,
@@ -149,16 +151,16 @@ class Shopper implements ArrayAccess
      */
     public function __construct(?array $data = null)
     {
-        $this->container['title'] = isset($data['title']) ? $data['title'] : null;
-        $this->container['first_name'] = isset($data['first_name']) ? $data['first_name'] : null;
-        $this->container['last_name'] = isset($data['last_name']) ? $data['last_name'] : null;
-        $this->container['middle_name'] = isset($data['middle_name']) ? $data['middle_name'] : null;
-        $this->container['phone'] = isset($data['phone']) ? $data['phone'] : null;
-        $this->container['email'] = isset($data['email']) ? $data['email'] : null;
-        $this->container['birth_date'] = isset($data['birth_date']) ? $data['birth_date'] : null;
-        $this->container['gender'] = isset($data['gender']) ? $data['gender'] : null;
-        $this->container['statistics'] = isset($data['statistics']) ? $data['statistics'] : null;
-        $this->container['billing_address'] = isset($data['billing_address']) ? $data['billing_address'] : null;
+        $this->container['title'] = $data['title'] ?? null;
+        $this->container['first_name'] = $data['first_name'] ?? null;
+        $this->container['last_name'] = $data['last_name'] ?? null;
+        $this->container['middle_name'] = $data['middle_name'] ?? null;
+        $this->container['phone'] = $data['phone'] ?? null;
+        $this->container['email'] = $data['email'] ?? null;
+        $this->container['birth_date'] = $data['birth_date'] ?? null;
+        $this->container['gender'] = $data['gender'] ?? null;
+        $this->container['statistics'] = $data['statistics'] ?? null;
+        $this->container['billing_address'] = $data['billing_address'] ?? null;
     }
 
     /**
@@ -166,7 +168,7 @@ class Shopper implements ArrayAccess
      *
      * @return array invalid properties with reasons
      */
-    public function listInvalidProperties()
+    public function listInvalidProperties(): array
     {
         $invalid_properties = [];
 
@@ -219,11 +221,7 @@ class Shopper implements ArrayAccess
         if (!in_array($this->container['gender'], $allowed_values)) {
             return false;
         }
-        if ($this->container['billing_address'] === null) {
-            return false;
-        }
-
-        return true;
+        return $this->container['billing_address'] !== null;
     }
 
     /**
@@ -243,7 +241,7 @@ class Shopper implements ArrayAccess
      *
      * @return $this
      */
-    public function setTitle($title)
+    public function setTitle($title): static
     {
         $this->container['title'] = $title;
 
@@ -267,7 +265,7 @@ class Shopper implements ArrayAccess
      *
      * @return $this
      */
-    public function setFirstName($first_name)
+    public function setFirstName($first_name): static
     {
         $this->container['first_name'] = $first_name;
 
@@ -291,7 +289,7 @@ class Shopper implements ArrayAccess
      *
      * @return $this
      */
-    public function setLastName($last_name)
+    public function setLastName($last_name): static
     {
         $this->container['last_name'] = $last_name;
 
@@ -315,7 +313,7 @@ class Shopper implements ArrayAccess
      *
      * @return $this
      */
-    public function setMiddleName($middle_name)
+    public function setMiddleName($middle_name): static
     {
         $this->container['middle_name'] = $middle_name;
 
@@ -339,7 +337,7 @@ class Shopper implements ArrayAccess
      *
      * @return $this
      */
-    public function setPhone($phone)
+    public function setPhone($phone): static
     {
         if (!is_null($phone) && (!preg_match('/^\\+?[\\d\\s]+$/', $phone))) {
             throw new \InvalidArgumentException("invalid value for {$phone} when calling Shopper., must conform to the pattern /^\\+?[\\d\\s]+$/.");
@@ -367,7 +365,7 @@ class Shopper implements ArrayAccess
      *
      * @return $this
      */
-    public function setEmail($email)
+    public function setEmail($email): static
     {
         $this->container['email'] = $email;
 
@@ -391,7 +389,7 @@ class Shopper implements ArrayAccess
      *
      * @return $this
      */
-    public function setBirthDate($birth_date)
+    public function setBirthDate($birth_date): static
     {
         $this->container['birth_date'] = $birth_date;
 
@@ -415,13 +413,13 @@ class Shopper implements ArrayAccess
      *
      * @return $this
      */
-    public function setGender($gender)
+    public function setGender($gender): static
     {
         $allowed_values = ['Male', 'Female', 'Other'];
         if (!is_null($gender)) {
             $gender = ucfirst(strtolower($gender));
         }
-        if (!is_null($gender) && (!in_array($gender, $allowed_values))) {
+        if (!in_array($gender, $allowed_values)) {
             throw new \InvalidArgumentException("Invalid value for 'gender', must be one of 'Male', 'Female', 'Other'");
         }
         $this->container['gender'] = $gender;
@@ -432,7 +430,7 @@ class Shopper implements ArrayAccess
     /**
      * Gets statistics.
      *
-     * @return \zipMoney\Model\ShopperStatistics
+     * @return ShopperStatistics
      */
     public function getStatistics()
     {
@@ -442,11 +440,11 @@ class Shopper implements ArrayAccess
     /**
      * Sets statistics.
      *
-     * @param \zipMoney\Model\ShopperStatistics $statistics
+     * @param ShopperStatistics $statistics
      *
      * @return $this
      */
-    public function setStatistics($statistics)
+    public function setStatistics($statistics): static
     {
         $this->container['statistics'] = $statistics;
 
@@ -456,7 +454,7 @@ class Shopper implements ArrayAccess
     /**
      * Gets billing_address.
      *
-     * @return \zipMoney\Model\Address
+     * @return Address
      */
     public function getBillingAddress()
     {
@@ -466,11 +464,11 @@ class Shopper implements ArrayAccess
     /**
      * Sets billing_address.
      *
-     * @param \zipMoney\Model\Address $billing_address
+     * @param Address $billing_address
      *
      * @return $this
      */
-    public function setBillingAddress($billing_address)
+    public function setBillingAddress($billing_address): static
     {
         $this->container['billing_address'] = $billing_address;
 
@@ -481,8 +479,6 @@ class Shopper implements ArrayAccess
      * Returns true if offset exists. False otherwise.
      *
      * @param int $offset Offset
-     *
-     * @return bool
      */
     public function offsetExists($offset): bool
     {
@@ -493,8 +489,6 @@ class Shopper implements ArrayAccess
      * Gets offset.
      *
      * @param int $offset Offset
-     *
-     * @return mixed
      */
     public function offsetGet($offset): mixed
     {
@@ -507,7 +501,7 @@ class Shopper implements ArrayAccess
      * @param int   $offset Offset
      * @param mixed $value  Value to be set
      */
-    public function offsetSet($offset, $value): void
+    public function offsetSet($offset, mixed $value): void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -528,15 +522,13 @@ class Shopper implements ArrayAccess
 
     /**
      * Gets the string presentation of the object.
-     *
-     * @return string
      */
-    public function __toString()
+    public function __toString(): string
     {
         if (defined('JSON_PRETTY_PRINT')) { // use JSON pretty print
-            return json_encode(\zipMoney\ObjectSerializer::sanitizeForSerialization($this), JSON_PRETTY_PRINT);
+            return (string) json_encode(ObjectSerializer::sanitizeForSerialization($this), JSON_PRETTY_PRINT);
         }
 
-        return json_encode(\zipMoney\ObjectSerializer::sanitizeForSerialization($this));
+        return (string) json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }

--- a/lib/Model/ShopperStatistics.php
+++ b/lib/Model/ShopperStatistics.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 /**
@@ -13,8 +14,9 @@ declare(strict_types=1);
 namespace zipMoney\Model;
 
 use ArrayAccess;
+use zipMoney\ObjectSerializer;
 
-class ShopperStatistics implements ArrayAccess
+class ShopperStatistics implements ArrayAccess, \Stringable
 {
     public const DISCRIMINATOR = 'subclass';
 
@@ -130,7 +132,7 @@ class ShopperStatistics implements ArrayAccess
      *
      * @return string[]
      */
-    public function getFraudCheckResultAllowableValues()
+    public function getFraudCheckResultAllowableValues(): array
     {
         return [
             self::FRAUD_CHECK_RESULT_PASS,
@@ -153,17 +155,17 @@ class ShopperStatistics implements ArrayAccess
      */
     public function __construct(?array $data = null)
     {
-        $this->container['account_created'] = isset($data['account_created']) ? $data['account_created'] : null;
-        $this->container['sales_total_count'] = isset($data['sales_total_count']) ? $data['sales_total_count'] : null;
-        $this->container['sales_total_amount'] = isset($data['sales_total_amount']) ? $data['sales_total_amount'] : null;
-        $this->container['sales_avg_amount'] = isset($data['sales_avg_amount']) ? $data['sales_avg_amount'] : null;
-        $this->container['sales_max_amount'] = isset($data['sales_max_amount']) ? $data['sales_max_amount'] : null;
-        $this->container['refunds_total_amount'] = isset($data['refunds_total_amount']) ? $data['refunds_total_amount'] : null;
-        $this->container['previous_chargeback'] = isset($data['previous_chargeback']) ? $data['previous_chargeback'] : null;
-        $this->container['currency'] = isset($data['currency']) ? $data['currency'] : null;
-        $this->container['last_login'] = isset($data['last_login']) ? $data['last_login'] : null;
-        $this->container['has_previous_purchases'] = isset($data['has_previous_purchases']) ? $data['has_previous_purchases'] : null;
-        $this->container['fraud_check_result'] = isset($data['fraud_check_result']) ? $data['fraud_check_result'] : null;
+        $this->container['account_created'] = $data['account_created'] ?? null;
+        $this->container['sales_total_count'] = $data['sales_total_count'] ?? null;
+        $this->container['sales_total_amount'] = $data['sales_total_amount'] ?? null;
+        $this->container['sales_avg_amount'] = $data['sales_avg_amount'] ?? null;
+        $this->container['sales_max_amount'] = $data['sales_max_amount'] ?? null;
+        $this->container['refunds_total_amount'] = $data['refunds_total_amount'] ?? null;
+        $this->container['previous_chargeback'] = $data['previous_chargeback'] ?? null;
+        $this->container['currency'] = $data['currency'] ?? null;
+        $this->container['last_login'] = $data['last_login'] ?? null;
+        $this->container['has_previous_purchases'] = $data['has_previous_purchases'] ?? null;
+        $this->container['fraud_check_result'] = $data['fraud_check_result'] ?? null;
     }
 
     /**
@@ -171,7 +173,7 @@ class ShopperStatistics implements ArrayAccess
      *
      * @return array invalid properties with reasons
      */
-    public function listInvalidProperties()
+    public function listInvalidProperties(): array
     {
         $invalid_properties = [];
 
@@ -189,14 +191,10 @@ class ShopperStatistics implements ArrayAccess
      *
      * @return bool True if all properties are valid
      */
-    public function valid()
+    public function valid(): bool
     {
         $allowed_values = ['pass', 'fail', 'unknown'];
-        if (!in_array($this->container['fraud_check_result'], $allowed_values)) {
-            return false;
-        }
-
-        return true;
+        return in_array($this->container['fraud_check_result'], $allowed_values);
     }
 
     /**
@@ -216,7 +214,7 @@ class ShopperStatistics implements ArrayAccess
      *
      * @return $this
      */
-    public function setAccountCreated($account_created)
+    public function setAccountCreated($account_created): static
     {
         $this->container['account_created'] = $account_created;
 
@@ -240,7 +238,7 @@ class ShopperStatistics implements ArrayAccess
      *
      * @return $this
      */
-    public function setSalesTotalCount($sales_total_count)
+    public function setSalesTotalCount($sales_total_count): static
     {
         $this->container['sales_total_count'] = $sales_total_count;
 
@@ -264,7 +262,7 @@ class ShopperStatistics implements ArrayAccess
      *
      * @return $this
      */
-    public function setSalesTotalAmount($sales_total_amount)
+    public function setSalesTotalAmount($sales_total_amount): static
     {
         $this->container['sales_total_amount'] = $sales_total_amount;
 
@@ -288,7 +286,7 @@ class ShopperStatistics implements ArrayAccess
      *
      * @return $this
      */
-    public function setSalesAvgAmount($sales_avg_amount)
+    public function setSalesAvgAmount($sales_avg_amount): static
     {
         $this->container['sales_avg_amount'] = $sales_avg_amount;
 
@@ -312,7 +310,7 @@ class ShopperStatistics implements ArrayAccess
      *
      * @return $this
      */
-    public function setSalesMaxAmount($sales_max_amount)
+    public function setSalesMaxAmount($sales_max_amount): static
     {
         $this->container['sales_max_amount'] = $sales_max_amount;
 
@@ -336,7 +334,7 @@ class ShopperStatistics implements ArrayAccess
      *
      * @return $this
      */
-    public function setRefundsTotalAmount($refunds_total_amount)
+    public function setRefundsTotalAmount($refunds_total_amount): static
     {
         $this->container['refunds_total_amount'] = $refunds_total_amount;
 
@@ -360,7 +358,7 @@ class ShopperStatistics implements ArrayAccess
      *
      * @return $this
      */
-    public function setPreviousChargeback($previous_chargeback)
+    public function setPreviousChargeback($previous_chargeback): static
     {
         $this->container['previous_chargeback'] = $previous_chargeback;
 
@@ -384,7 +382,7 @@ class ShopperStatistics implements ArrayAccess
      *
      * @return $this
      */
-    public function setCurrency($currency)
+    public function setCurrency($currency): static
     {
         $this->container['currency'] = $currency;
 
@@ -408,7 +406,7 @@ class ShopperStatistics implements ArrayAccess
      *
      * @return $this
      */
-    public function setLastLogin($last_login)
+    public function setLastLogin($last_login): static
     {
         $this->container['last_login'] = $last_login;
 
@@ -432,7 +430,7 @@ class ShopperStatistics implements ArrayAccess
      *
      * @return $this
      */
-    public function setHasPreviousPurchases($has_previous_purchases)
+    public function setHasPreviousPurchases($has_previous_purchases): static
     {
         $this->container['has_previous_purchases'] = $has_previous_purchases;
 
@@ -456,7 +454,7 @@ class ShopperStatistics implements ArrayAccess
      *
      * @return $this
      */
-    public function setFraudCheckResult($fraud_check_result)
+    public function setFraudCheckResult($fraud_check_result): static
     {
         $allowed_values = ['pass', 'fail', 'unknown'];
         if (!is_null($fraud_check_result) && (!in_array($fraud_check_result, $allowed_values))) {
@@ -471,8 +469,6 @@ class ShopperStatistics implements ArrayAccess
      * Returns true if offset exists. False otherwise.
      *
      * @param int $offset Offset
-     *
-     * @return bool
      */
     public function offsetExists($offset): bool
     {
@@ -483,8 +479,6 @@ class ShopperStatistics implements ArrayAccess
      * Gets offset.
      *
      * @param int $offset Offset
-     *
-     * @return mixed
      */
     public function offsetGet($offset): mixed
     {
@@ -497,7 +491,7 @@ class ShopperStatistics implements ArrayAccess
      * @param int   $offset Offset
      * @param mixed $value  Value to be set
      */
-    public function offsetSet($offset, $value): void
+    public function offsetSet($offset, mixed $value): void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -518,15 +512,13 @@ class ShopperStatistics implements ArrayAccess
 
     /**
      * Gets the string presentation of the object.
-     *
-     * @return string
      */
-    public function __toString()
+    public function __toString(): string
     {
         if (defined('JSON_PRETTY_PRINT')) { // use JSON pretty print
-            return json_encode(\zipMoney\ObjectSerializer::sanitizeForSerialization($this), JSON_PRETTY_PRINT);
+            return (string) json_encode(ObjectSerializer::sanitizeForSerialization($this), JSON_PRETTY_PRINT);
         }
 
-        return json_encode(\zipMoney\ObjectSerializer::sanitizeForSerialization($this));
+        return (string) json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }

--- a/lib/Model/Token.php
+++ b/lib/Model/Token.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 /**
@@ -13,8 +14,9 @@ declare(strict_types=1);
 namespace zipMoney\Model;
 
 use ArrayAccess;
+use zipMoney\ObjectSerializer;
 
-class Token implements ArrayAccess
+class Token implements ArrayAccess, \Stringable
 {
     public const DISCRIMINATOR = 'subclass';
 
@@ -107,10 +109,10 @@ class Token implements ArrayAccess
      */
     public function __construct(?array $data = null)
     {
-        $this->container['id'] = isset($data['id']) ? $data['id'] : null;
-        $this->container['value'] = isset($data['value']) ? $data['value'] : null;
-        $this->container['active'] = isset($data['active']) ? $data['active'] : null;
-        $this->container['created_date'] = isset($data['created_date']) ? $data['created_date'] : null;
+        $this->container['id'] = $data['id'] ?? null;
+        $this->container['value'] = $data['value'] ?? null;
+        $this->container['active'] = $data['active'] ?? null;
+        $this->container['created_date'] = $data['created_date'] ?? null;
     }
 
     /**
@@ -118,7 +120,7 @@ class Token implements ArrayAccess
      *
      * @return array invalid properties with reasons
      */
-    public function listInvalidProperties()
+    public function listInvalidProperties(): array
     {
         $invalid_properties = [];
 
@@ -155,11 +157,7 @@ class Token implements ArrayAccess
         if ($this->container['active'] === null) {
             return false;
         }
-        if ($this->container['created_date'] === null) {
-            return false;
-        }
-
-        return true;
+        return $this->container['created_date'] !== null;
     }
 
     /**
@@ -179,7 +177,7 @@ class Token implements ArrayAccess
      *
      * @return $this
      */
-    public function setId($id)
+    public function setId($id): static
     {
         $this->container['id'] = $id;
 
@@ -203,7 +201,7 @@ class Token implements ArrayAccess
      *
      * @return $this
      */
-    public function setValue($value)
+    public function setValue($value): static
     {
         $this->container['value'] = $value;
 
@@ -227,7 +225,7 @@ class Token implements ArrayAccess
      *
      * @return $this
      */
-    public function setActive($active)
+    public function setActive($active): static
     {
         $this->container['active'] = $active;
 
@@ -251,7 +249,7 @@ class Token implements ArrayAccess
      *
      * @return $this
      */
-    public function setCreatedDate($created_date)
+    public function setCreatedDate($created_date): static
     {
         $this->container['created_date'] = $created_date;
 
@@ -262,8 +260,6 @@ class Token implements ArrayAccess
      * Returns true if offset exists. False otherwise.
      *
      * @param int $offset Offset
-     *
-     * @return bool
      */
     public function offsetExists($offset): bool
     {
@@ -274,8 +270,6 @@ class Token implements ArrayAccess
      * Gets offset.
      *
      * @param int $offset Offset
-     *
-     * @return mixed
      */
     public function offsetGet($offset): mixed
     {
@@ -288,7 +282,7 @@ class Token implements ArrayAccess
      * @param int   $offset Offset
      * @param mixed $value  Value to be set
      */
-    public function offsetSet($offset, $value): void
+    public function offsetSet($offset, mixed $value): void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -309,15 +303,13 @@ class Token implements ArrayAccess
 
     /**
      * Gets the string presentation of the object.
-     *
-     * @return string
      */
-    public function __toString()
+    public function __toString(): string
     {
         if (defined('JSON_PRETTY_PRINT')) { // use JSON pretty print
-            return json_encode(\zipMoney\ObjectSerializer::sanitizeForSerialization($this), JSON_PRETTY_PRINT);
+            return (string) json_encode(ObjectSerializer::sanitizeForSerialization($this), JSON_PRETTY_PRINT);
         }
 
-        return json_encode(\zipMoney\ObjectSerializer::sanitizeForSerialization($this));
+        return (string) json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }

--- a/lib/ObjectSerializer.php
+++ b/lib/ObjectSerializer.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 /**
@@ -28,7 +29,7 @@ class ObjectSerializer
      *
      * @return object|string serialized form of $data
      */
-    public static function sanitizeForSerialization($data)
+    public static function sanitizeForSerialization(mixed $data): int|float|string|bool|null|array|\stdClass
     {
         if (is_scalar($data) || null === $data) {
             return $data;
@@ -49,10 +50,10 @@ class ObjectSerializer
             foreach (array_keys($data::zipTypes()) as $property) {
                 $getterArr = $data::getters();
                 $getter = $getterArr[$property];
-                if (method_exists(get_class($data), $getter) && $data->{$getter}() !== null) {
+                if (method_exists($data::class, $getter) && $data->{$getter}() !== null) {
                     $values[$attr[$property]] = self::sanitizeForSerialization($data->{$getter}());
                 }
-                if (method_exists(get_class($data), 'get') && $data->get($property) !== null) {
+                if (method_exists($data::class, 'get') && $data->get($property) !== null) {
                     $values[$attr[$property]] = self::sanitizeForSerialization($data->get($property));
                 }
             }
@@ -88,7 +89,7 @@ class ObjectSerializer
      *
      * @return string the serialized object
      */
-    public function toPathValue($value)
+    public function toPathValue($value): string
     {
         return rawurlencode($this->toString($value));
     }
@@ -172,25 +173,19 @@ class ObjectSerializer
      *
      * @return string
      */
-    public function serializeCollection(array $collection, $collectionFormat, $allowCollectionFormatMulti = false)
+    public function serializeCollection(array $collection, $collectionFormat, $allowCollectionFormatMulti = false): string|array|null
     {
         if ($allowCollectionFormatMulti && ('multi' === $collectionFormat)) {
             // http_build_query() almost does the job for us. We just
             // need to fix the result of multidimensional arrays.
-            return preg_replace('/%5B[0-9]+%5D=/', '=', http_build_query($collection, '', '&'));
+            return preg_replace('/%5B\d+%5D=/', '=', http_build_query($collection, '', '&'));
         }
-        switch ($collectionFormat) {
-            case 'pipes':
-                return implode('|', $collection);
-            case 'tsv':
-                return implode("\t", $collection);
-            case 'ssv':
-                return implode(' ', $collection);
-            case 'csv':
-                // Deliberate fall through. CSV is default format.
-            default:
-                return implode(',', $collection);
-        }
+        return match ($collectionFormat) {
+            'pipes' => implode('|', $collection),
+            'tsv' => implode("\t", $collection),
+            'ssv' => implode(' ', $collection),
+            default => implode(',', $collection),
+        };
     }
 
     /**
@@ -203,12 +198,12 @@ class ObjectSerializer
      *
      * @return null|array|object an single or an array of $class instances
      */
-    public static function deserialize($data, $class, $httpHeaders = null)
+    public static function deserialize(mixed $data, $class, $httpHeaders = null)
     {
         if (null === $data) {
             return null;
         }
-        if (substr($class, 0, 4) === 'map[') { // for associative array e.g. map[string,int]
+        if (str_starts_with($class, 'map[')) { // for associative array e.g. map[string,int]
             $inner = substr($class, 4, -1);
             $deserialized = [];
             if (strrpos($inner, ',') !== false) {
@@ -224,16 +219,14 @@ class ObjectSerializer
         if (strcasecmp(substr($class, -2), '[]') === 0) {
             $subClass = substr($class, 0, -2);
             $values = [];
-            foreach ($data as $key => $value) {
+            foreach ($data as $value) {
                 $values[] = self::deserialize($value, $subClass, null);
             }
 
             return $values;
         }
         if ($class === 'object') {
-            settype($data, 'array');
-
-            return $data;
+            return (array) $data;
         }
         if ($class === '\DateTime') {
             // Some API's return an invalid, empty string as a

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,22 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit bootstrap="./vendor/autoload.php"
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+         bootstrap="./vendor/autoload.php"
+         cacheDirectory="build/.phpunit.cache"
          colors="true"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true"
          stopOnFailure="false">
     <testsuites>
-        <testsuite>
-            <directory>./test/</directory>
-            <directory>./test/Api</directory>
-            <directory>./test/Model</directory>
+        <testsuite name="default">
+            <directory>./test</directory>
         </testsuite>
     </testsuites>
 
-    <filter>
-        <whitelist processUncoveredFilesFromWhitelist="true">
+    <source>
+        <include>
             <directory suffix=".php">./lib/Api</directory>
             <directory suffix=".php">./lib/Model</directory>
-        </whitelist>
-    </filter>
+        </include>
+    </source>
 </phpunit>

--- a/rector.php
+++ b/rector.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Rector\Set\ValueObject\LevelSetList;
+use Rector\Set\ValueObject\SetList;
+
+return RectorConfig::configure()
+    ->withPaths([
+        __DIR__ . '/lib',
+        __DIR__ . '/test',
+    ])
+    // Don't touch generated/auxiliary files that aren't real source.
+    ->withSkip([
+        __DIR__ . '/vendor',
+        __DIR__ . '/build',
+        __DIR__ . '/docs',
+    ])
+    // Min supported runtime is PHP 8.0 (see composer.json) — do not emit newer syntax.
+    ->withPhpSets(php80: true)
+    ->withSets([
+        SetList::CODE_QUALITY,
+        SetList::DEAD_CODE,
+        SetList::TYPE_DECLARATION,
+        LevelSetList::UP_TO_PHP_80,
+    ])
+    ->withImportNames(importShortClasses: false);

--- a/test/Api/ChargesApiTest.php
+++ b/test/Api/ChargesApiTest.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 /**
  * ChargesApiTest.
@@ -19,46 +20,40 @@ class ChargesApiTest extends Setup
      * Test case for chargesCancel.
      *
      * Cancel a charge.
-     *
-     * @expectedException  \zipMoney\ApiException
-     *
-     * @expectedExceptionMessage An error occurred while processing payment
      */
-    public function testChargesCancel()
+    public function testChargesCancel(): void
     {
-        $chargesApi = new ChargesApi;
-        $response = $chargesApi->chargesCancel('1');
+        $this->expectException(ApiException::class);
+
+        $chargesApi = new ChargesApi();
+        $chargesApi->chargesCancel('1');
     }
 
     /**
      * Test case for chargesCapture.
      *
      * Capture a charge.
-     *
-     * @expectedException  \zipMoney\ApiException
-     *
-     * @expectedExceptionMessage An error occurred while processing payment
      */
-    public function testChargesCapture()
+    public function testChargesCapture(): void
     {
-        $chargesApi = new ChargesApi;
+        $this->expectException(ApiException::class);
+
+        $chargesApi = new ChargesApi();
         $req = $this->_payloadHelper->getCapturePayload();
-        $response = $chargesApi->chargesCapture('1', $req);
+        $chargesApi->chargesCapture('1', $req);
     }
 
     /**
      * Test case for chargesCreate.
      *
      * Create a charge.
-     *
-     * @expectedException  \zipMoney\ApiException
-     *
-     * @expectedExceptionMessage An error occurred while processing payment
      */
-    public function testChargesCreate()
+    public function testChargesCreate(): void
     {
-        $checkoutsApi = new CheckoutsApi;
-        $chargesApi = new ChargesApi;
+        $this->expectException(ApiException::class);
+
+        $checkoutsApi = new CheckoutsApi();
+        $chargesApi = new ChargesApi();
 
         $req = $this->_payloadHelper->getCheckoutPayload();
         $checkout = $checkoutsApi->checkoutsCreate($req);
@@ -66,27 +61,21 @@ class ChargesApiTest extends Setup
         $this->_payloadHelper->setCheckoutId($checkout->getId());
 
         $chargeReq = $this->_payloadHelper->getChargePayload();
-        $response = $chargesApi->chargesCreate($chargeReq);
-
-        $this->assertTrue(true);
+        $chargesApi->chargesCreate($chargeReq);
     }
 
     /**
      * Test case for chargesCreateRaisesException.
      *
      * Create a charge.
-     *
-     * @expectedException  \zipMoney\ApiException
-     *
-     * @expectedExceptionMessage An error occurred while processing payment
      */
-    public function testChargesCreateRaisesException()
+    public function testChargesCreateRaisesException(): void
     {
-        $chargesApi = new ChargesApi;
-        $chargeReq = $this->_payloadHelper->getChargePayload();
-        $response = $chargesApi->chargesCreate($chargeReq);
+        $this->expectException(ApiException::class);
 
-        $this->assertTrue(true);
+        $chargesApi = new ChargesApi();
+        $chargeReq = $this->_payloadHelper->getChargePayload();
+        $chargesApi->chargesCreate($chargeReq);
     }
 
     /**
@@ -94,7 +83,7 @@ class ChargesApiTest extends Setup
      *
      * List charges.
      */
-    public function testChargesList()
+    public function testChargesList(): void
     {
         $this->assertTrue(true);
     }
@@ -104,7 +93,7 @@ class ChargesApiTest extends Setup
      *
      * Retrieve a charge.
      */
-    public function testChargesRetrieve()
+    public function testChargesRetrieve(): void
     {
         $this->assertTrue(true);
     }

--- a/test/Api/CheckoutsApiTest.php
+++ b/test/Api/CheckoutsApiTest.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 /**
  * CheckoutsApiTest.
@@ -19,10 +20,10 @@ class CheckoutsApiTest extends Setup
      *
      * Create a checkout.
      */
-    public function testCheckoutsCreate()
+    public function testCheckoutsCreate(): void
     {
         try {
-            $checkoutsApi = new CheckoutsApi;
+            $checkoutsApi = new CheckoutsApi();
             $req = $this->_payloadHelper->getCheckoutPayload();
             $checkout = $checkoutsApi->checkoutsCreate($req);
 
@@ -38,7 +39,7 @@ class CheckoutsApiTest extends Setup
      *
      * Retrieve a checkout.
      */
-    public function testCheckoutsGet()
+    public function testCheckoutsGet(): void
     {
         $this->assertTrue(true);
     }

--- a/test/Api/RefundsApiTest.php
+++ b/test/Api/RefundsApiTest.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 /**
  * RefundsApiTest
@@ -19,18 +20,15 @@ class RefundsApiTest extends Setup
      * Test case for refundsCreate.
      *
      * Create a refund.
-     *
-     * @expectedException  \zipMoney\ApiException
-     *
-     * @expectedExceptionMessage An error occurred while processing payment
      */
-    public function testRefundsCreate()
+    public function testRefundsCreate(): void
     {
-        $refundsApi = new RefundsApi;
+        $this->expectException(ApiException::class);
+
+        $refundsApi = new RefundsApi();
         $this->_payloadHelper->setChargeId(1);
         $req = $this->_payloadHelper->getRefundPayload();
-        $response = $refundsApi->refundsCreate($req);
-        $this->assertTrue(true);
+        $refundsApi->refundsCreate($req);
     }
 
     /**
@@ -38,7 +36,7 @@ class RefundsApiTest extends Setup
      *
      * List refunds.
      */
-    public function testRefundsList()
+    public function testRefundsList(): void
     {
         $this->assertTrue(true);
     }
@@ -48,7 +46,7 @@ class RefundsApiTest extends Setup
      *
      * Retrieve a refund.
      */
-    public function testRefundsRetrieve()
+    public function testRefundsRetrieve(): void
     {
         $this->assertTrue(true);
     }

--- a/test/ConfigurationTest.php
+++ b/test/ConfigurationTest.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 /**
@@ -13,7 +14,7 @@ namespace zipMoney;
 
 class ConfigurationTest extends Setup
 {
-    public function testPlatform()
+    public function testPlatform(): void
     {
         $config = Configuration::getDefaultConfiguration();
 
@@ -21,26 +22,25 @@ class ConfigurationTest extends Setup
         $this->assertEquals($config->getPlatform(), 'Magento/1.0.0');
     }
 
-    public function testEnvironment()
+    public function testEnvironment(): void
     {
         $config = Configuration::getDefaultConfiguration();
 
         $config->setEnvironment('sandbox');
         $this->assertEquals($config->getEnvironment(), 'sandbox');
-        $this->assertEquals($config->getHost(), 'https://global-api.sand.au.edge.zip.co/merchant');
+        $this->assertEquals($config->getHost(), 'https://sand.merchant-api.com/merchant');
 
         $config->setEnvironment('production');
         $this->assertEquals($config->getEnvironment(), 'production');
-        $this->assertEquals($config->getHost(), 'https://global-api.prod.au.edge.zip.co/merchant');
+        $this->assertEquals($config->getHost(), 'https://merchant-api.com/merchant');
     }
 
-    public function testApiHeaders()
+    public function testApiHeaders(): void
     {
         $config = Configuration::getDefaultConfiguration();
 
-        $config->setPlatform('Magento/1.0.0')
-            ->setDefaultHeaders('sandbox');
-        $packageJson = file_get_contents(dirname(__FILE__) . './../composer.json');
+        $config->setPlatform('Magento/1.0.0')->setDefaultHeaders();
+        $packageJson = file_get_contents(__DIR__ . './../composer.json');
         $data = json_decode($packageJson);
         $version = $data->version;
 
@@ -48,10 +48,10 @@ class ConfigurationTest extends Setup
         $this->assertEquals($config->getDefaultHeaders(), ['Zip-Version' => '2017-03-01']);
     }
 
-    public function testPackageVersion()
+    public function testPackageVersion(): void
     {
         $config = Configuration::getDefaultConfiguration();
-        $packageJson = file_get_contents(dirname(__FILE__) . './../composer.json');
+        $packageJson = file_get_contents(__DIR__ . './../composer.json');
         $data = json_decode($packageJson);
         $this->assertEquals($config->getPackageVersion(), $data->version);
     }

--- a/test/Helper/Payload.php
+++ b/test/Helper/Payload.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 /**
  * Payload.
@@ -41,25 +42,25 @@ class Payload
 
     protected $_chargeId;
 
-    public function getCheckoutPayload()
+    public function getCheckoutPayload(): CheckoutRequest
     {
         $checkoutReq = new CheckoutRequest();
 
         $checkoutReq->setType('standard')
             ->setShopper($this->getShopper())
-            ->setOrder($this->getOrderDetails(new CheckoutOrder))
+            ->setOrder($this->getOrderDetails(new CheckoutOrder()))
             ->setMetadata($this->getMetadata())
             ->setConfig($this->getCheckoutConfiguration());
 
         return $checkoutReq;
     }
 
-    public function getChargePayload()
+    public function getChargePayload(): ChargeRequest
     {
         $chargeReq = new ChargeRequest();
 
         $chargeReq->setAmount(100)
-            ->setOrder($this->getOrderDetails(new ChargeOrder))
+            ->setOrder($this->getOrderDetails(new ChargeOrder()))
             ->setCurrency('AUD')
             ->setCapture(true)
             ->setMetadata($this->getMetadata())
@@ -68,7 +69,7 @@ class Payload
         return $chargeReq;
     }
 
-    public function getRefundPayload()
+    public function getRefundPayload(): RefundRequest
     {
         $chargeReq = new RefundRequest();
 
@@ -80,7 +81,7 @@ class Payload
         return $chargeReq;
     }
 
-    public function getCapturePayload()
+    public function getCapturePayload(): CaptureChargeRequest
     {
         $captureChargeReq = new CaptureChargeRequest();
 
@@ -89,9 +90,9 @@ class Payload
         return $captureChargeReq;
     }
 
-    public function getShopper()
+    public function getShopper(): Shopper
     {
-        $shopper = new Shopper;
+        $shopper = new Shopper();
 
         $shopper->setEmail('test@zipmoney.com.au');
         $shopper->setFirstName('zipMoney');
@@ -101,7 +102,7 @@ class Payload
         $shopper->setPhone('+610400000000');
         $shopper->setTitle('Mr.');
 
-        $statistics = new ShopperStatistics;
+        $statistics = new ShopperStatistics();
 
         $statistics->setAccountCreated('2017-01-01')
             ->setSalesTotalCount(1000)
@@ -114,7 +115,7 @@ class Payload
 
         $shopper->setStatistics($statistics);
 
-        $address = new Address;
+        $address = new Address();
 
         $address->setFirstName('zipMoney');
         $address->setLastName('Test');
@@ -129,16 +130,16 @@ class Payload
         return $shopper;
     }
 
-    public function getShippingDetails()
+    public function getShippingDetails(): string
     {
         return '';
     }
 
     public function getOrderDetails($reqOrder)
     {
-        $shipping = new OrderShipping;
+        $shipping = new OrderShipping();
 
-        $address = new Address;
+        $address = new Address();
 
         $address->setFirstName('zipMoney');
         $address->setLastName('Test');
@@ -150,7 +151,7 @@ class Payload
 
         $shipping->setAddress($address);
 
-        $orderItem = new OrderItem;
+        $orderItem = new OrderItem();
 
         $orderItem->setName('Test Product')
             ->setAmount(100)
@@ -166,7 +167,7 @@ class Payload
 
         $orderItems[] = $orderItem;
         // Discount Item
-        $discountItem = new OrderItem;
+        $discountItem = new OrderItem();
         $discountItem->setName('Discount');
         $discountItem->setAmount(-10);
         $discountItem->setQuantity(1);
@@ -174,7 +175,7 @@ class Payload
         $orderItems[] = $discountItem;
 
         // Shipping Item
-        $shippingItem = new OrderItem;
+        $shippingItem = new OrderItem();
         $shippingItem->setName('Shipping');
         $shippingItem->setAmount(15);
         $shippingItem->setType('shipping');
@@ -182,7 +183,7 @@ class Payload
         $orderItems[] = $shippingItem;
 
         // Tax Item
-        $taxItem = new OrderItem;
+        $taxItem = new OrderItem();
         $taxItem->setName('Tax');
         $taxItem->setAmount(5);
         $taxItem->setType('tax');
@@ -203,12 +204,12 @@ class Payload
         return $reqOrder;
     }
 
-    public function getMetadata()
+    public function getMetadata(): Metadata
     {
-        return new Metadata;
+        return new Metadata();
     }
 
-    public function setCheckoutId($checkout_id)
+    public function setCheckoutId($checkout_id): void
     {
         $this->_checkoutId = $checkout_id;
     }
@@ -218,7 +219,7 @@ class Payload
         return $this->_checkoutId;
     }
 
-    public function setChargeId($charge_id)
+    public function setChargeId($charge_id): void
     {
         $this->_chargeId = $charge_id;
     }
@@ -228,18 +229,18 @@ class Payload
         return $this->_chargeId;
     }
 
-    public function getAuthority()
+    public function getAuthority(): Authority
     {
         $checkout_id = $this->getCheckoutId();
 
-        $authority = new Authority;
+        $authority = new Authority();
         $authority->setType('checkout_id')
             ->setValue($checkout_id);
 
         return $authority;
     }
 
-    public function getCheckoutConfiguration()
+    public function getCheckoutConfiguration(): CheckoutConfiguration
     {
         $checkout_config = new CheckoutConfiguration();
 

--- a/test/Setup.php
+++ b/test/Setup.php
@@ -1,11 +1,13 @@
 <?php
+
 declare(strict_types=1);
 
 namespace zipMoney;
 
+use PHPUnit\Framework\TestCase;
 use zipMoney\Helper\Payload;
 
-class Setup extends \PHPUnit\Framework\TestCase
+class Setup extends TestCase
 {
     protected $_payloadHelper;
 
@@ -14,9 +16,9 @@ class Setup extends \PHPUnit\Framework\TestCase
      */
     public function setUp(): void
     {
-        $this->_payloadHelper = new Payload;
+        $this->_payloadHelper = new Payload();
 
-        $auth = parse_ini_file('auth.ini');
+        $auth = parse_ini_file(__DIR__ . '/auth.ini');
 
         Configuration::getDefaultConfiguration()->setApiKey('Authorization', "Bearer {$auth['private_key']}");
         Configuration::getDefaultConfiguration()->setEnvironment('sandbox');


### PR DESCRIPTION
- Fix file_get_contents warning in Configuration::getPackageVersion(): broken "lib./../composer.json" path corrected to "/../composer.json" and guarded with is_file()/is_readable() before reading.
- Add Rector and PHP-CS-Fixer as dev dependencies with configs; apply their fixes across lib/ and test/ (return/param types, null coalescing, short array syntax, PSR-12 formatting).
- Run all tooling via ephemeral standard Docker images pinned to PHP 8.1 (Makefile); no local PHP or custom image required.
- Migrate tests to PHPUnit 10: modernize phpunit.xml.dist schema, convert @expectedException annotations to expectException(), fix auth.ini path, relocate result cache to build/.
- Correct stale sandbox/production host expectations in ConfigurationTest to match the actual SDK configuration.
- Add .gitattributes to enforce LF line endings across platforms.
- Bump package version to 1.0.19.