### PR TITLE
ZES-82: handle cURL transport failures in ApiClient instead of fataling

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "zipmoney/merchantapi-php",
-    "version": "1.0.19",
+    "version": "1.0.20",
     "description": "",
     "keywords": [
         "zipmoney",

--- a/lib/ApiClient.php
+++ b/lib/ApiClient.php
@@ -215,8 +215,19 @@ class ApiClient
             // Make the request
             $response = curl_exec($curl);
             $http_header_size = curl_getinfo($curl, CURLINFO_HEADER_SIZE);
-            $http_header = $this->httpParseHeaders(substr($response, 0, $http_header_size));
-            $http_body = substr($response, $http_header_size);
+
+            // curl_exec() returns false on a transport-level failure (TLS, DNS,
+            // connection). There is no payload to parse, so guard substr() — under
+            // declare(strict_types=1) substr(false, ...) is a fatal TypeError. The
+            // http_code === 0 handler below turns this into a proper ApiException.
+            if ($response === false) {
+                $http_header = [];
+                $http_body = '';
+            } else {
+                $http_header = $this->httpParseHeaders(substr($response, 0, $http_header_size));
+                $http_body = substr($response, $http_header_size);
+            }
+
             $response_info = curl_getinfo($curl);
             $count++;
             $msg = curl_error($curl);

--- a/test/Api/ApiClientResilienceTest.php
+++ b/test/Api/ApiClientResilienceTest.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * ApiClientResilienceTest.
+ *
+ * @category Class
+ *
+ * @see     https://github.com/zipMoney/merchantapi-php
+ */
+
+namespace zipMoney;
+
+use zipMoney\Api\CheckoutsApi;
+
+class ApiClientResilienceTest extends Setup
+{
+    /**
+     * A transport-level cURL failure must surface as a catchable ApiException,
+     * not a fatal TypeError. Here the host is unreachable so curl_exec() returns
+     * false; under declare(strict_types=1) substr(false, ...) would otherwise
+     * throw TypeError instead of letting the http_code === 0 handler run.
+     */
+    public function testTransportFailureThrowsApiExceptionNotTypeError(): void
+    {
+        // Unreachable address — connection is refused immediately, curl_exec() === false.
+        Configuration::getDefaultConfiguration()->setHost('https://127.0.0.1:1/merchant');
+
+        $this->expectException(ApiException::class);
+
+        $checkoutsApi = new CheckoutsApi();
+        $req = $this->_payloadHelper->getCheckoutPayload();
+        $checkoutsApi->checkoutsCreate($req);
+    }
+}


### PR DESCRIPTION
## Problem

`ApiClient::callApi()` fataled with an uncatchable `TypeError` on any cURL transport-level failure (TLS / DNS / connection).

`curl_exec()` returns `false` in those cases, and the result was passed straight into `substr($response, ...)`. Under `declare(strict_types=1)` (present in the SDK since 1.0.18) `substr(false, ...)` is a hard `TypeError`, surfacing as an HTTP 500 in consumers (e.g. the WooCommerce plugin) instead of a handled error.

Observed chain: `create_checkout → checkoutsCreate → callApi → substr(false, 0, 0)` → `TypeError` at `ApiClient.php`. Root trigger in the field was a missing CA bundle in the host container (SSL verify failure → `curl_exec()` === false).

## Fix

- Guard the `substr()` calls: when `curl_exec()` returns `false` there is no payload to parse, so the **existing** `http_code === 0` handler runs and throws a proper `ApiException` carrying the cURL error message (e.g. `SSL certificate problem: unable to get local issuer certificate`). Callers already catch `ApiException`.
- The retry loop is preserved.

## Test

- `ApiClientResilienceTest` points the client at an unreachable host (`127.0.0.1:1`, connection refused → `curl_exec()` === false) and asserts an `ApiException` is thrown — not a `TypeError`. Fails without the fix (a `TypeError` is not an `ApiException`).

## Notes

- Not a regression from the 1.0.19 refactor: `declare(strict_types=1)` was already in 1.0.18; the missing `false` check pre-dates it.
- Version bumped to **1.0.20**.
- Verified: full suite green (16 tests) on PHP 8.1; `php -l` clean on PHP 8.0 and 8.3; Rector and PHP-CS-Fixer dry-runs clean.